### PR TITLE
iso offline install and release manifests

### DIFF
--- a/iso/configs/airootfs/root/.automated_script.sh
+++ b/iso/configs/airootfs/root/.automated_script.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euo pipefail
 
 use_ryoku_helpers() {
@@ -115,9 +115,8 @@ install_base_system() {
 
   # arch-chroot bind-mounts the live ISO's /etc/resolv.conf into the
   # chroot, but in offline-install mode that file may be empty. Write
-  # a working resolv.conf so the chroot can resolve mirror hostnames
-  # when install.sh switches pacman to online repos and yay clones
-  # from AUR. Cloudflare + Google as resilient defaults.
+  # a working first-boot fallback; the install itself must stay on the
+  # bundled offline mirror and never require DNS.
   cat > /mnt/etc/resolv.conf <<RESOLV
 # written by ryoku-iso during install; install.sh / NetworkManager will
 # replace this on first boot with the system-managed config.
@@ -170,7 +169,6 @@ chroot_bash() {
   HOME=/home/$RYOKU_USER \
     arch-chroot -u $RYOKU_USER /mnt/ \
     env -i RYOKU_CHROOT_INSTALL=1 \
-    RYOKU_ONLINE_INSTALL=1 \
     RYOKU_USER_NAME="$(<user_full_name.txt)" \
     RYOKU_USER_EMAIL="$(<user_email_address.txt)" \
     RYOKU_MIRROR="$RYOKU_MIRROR" \

--- a/tests/iso-offline-install-mode.sh
+++ b/tests/iso-offline-install-mode.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+AUTOMATED_SCRIPT="$ROOT_DIR/iso/configs/airootfs/root/.automated_script.sh"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+[[ -f $AUTOMATED_SCRIPT ]] || fail "missing ISO automated script"
+
+if ! grep -Eq 'env -i RYOKU_CHROOT_INSTALL=1[[:space:]]*\\' "$AUTOMATED_SCRIPT"; then
+  fail "ISO chroot should still mark the install as a Ryoku chroot install"
+fi
+
+if grep -Eq '^[[:space:]]*RYOKU_ONLINE_INSTALL=1[[:space:]]*\\' "$AUTOMATED_SCRIPT"; then
+  fail "ISO chroot must not force online install mode; offline mirror installs should not need DNS"
+fi
+
+echo "PASS: ISO chroot install stays offline-first"


### PR DESCRIPTION
## Summary

- Keep the live ISO chroot install offline-first by no longer exporting `RYOKU_ONLINE_INSTALL=1` from `.automated_script.sh`.
- Add a regression test that fails if the ISO path forces online install mode again.
- Add ISO tracking IDs to CI/local ISO names, embed `/etc/ryoku-iso-release`, generate JSON and JS release manifests, and upload them with release artifacts.
- Update release pipeline docs for tracked ISO names and manifests.

## Root Cause

The ISO chroot environment forced `RYOKU_ONLINE_INSTALL=1`, which made `install/preflight/pacman.sh` swap to online pacman repos and made `yay-bootstrap.sh` attempt AUR/GitHub. Offline installs then failed DNS and cascaded into missing package/config failures.

## Validation

- `bash tests/iso-offline-install-mode.sh`
- `bash tests/iso-tracking-id.sh`
- `bash tests/aur-offline-bootstrap.sh`
- `bash tests/ryoku-base-packaging.sh`
- `bash tests/ryoku-aur-core-packaging.sh`
- `bash tests/niri-shell-merge-readiness.sh`
- `bash -n iso/configs/airootfs/root/.automated_script.sh iso/bin/ryoku-iso-manifest tests/iso-offline-install-mode.sh tests/iso-tracking-id.sh`
- `git diff --check`
- `git diff --cached --check`

## Notes

Left `docs/superpowers/specs/2026-05-11-iso-tracking-id-design.md` unstaged and unpushed per instruction that `docs/superpowers` and plan files should not be pushed.
