### PR TITLE
Add update doctor recovery flow

### DIFF
--- a/.github/workflows/pr-shell-script-alert.yml
+++ b/.github/workflows/pr-shell-script-alert.yml
@@ -1,0 +1,141 @@
+name: PR Shell Script Alert
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  shell-script-alert:
+    name: Shell script security alert
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR contents
+        uses: actions/checkout@v4
+
+      - name: Scan changed files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          changed_files="$(mktemp)"
+          flagged_files="$(mktemp)"
+
+          gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
+            --jq '.[].filename' >"$changed_files"
+
+          is_execution_sensitive_path() {
+            local path="$1"
+
+            [[ $path == "boot.sh" ]] && return 0
+            [[ $path == "install.sh" ]] && return 0
+            [[ $path == bin/* ]] && return 0
+            [[ $path == install/* ]] && return 0
+            [[ $path == migrations/* ]] && return 0
+            [[ $path == iso/bin/* ]] && return 0
+            [[ $path == iso/builder/* ]] && return 0
+            [[ $path == shell/scripts/* ]] && return 0
+            [[ $path == default/systemd/system-sleep/* ]] && return 0
+            [[ $path == .github/workflows/*.yml ]] && return 0
+            [[ $path == .github/workflows/*.yaml ]] && return 0
+
+            return 1
+          }
+
+          has_shell_shebang() {
+            local path="$1"
+            local first_line
+
+            [[ -f $path ]] || return 1
+            first_line="$(LC_ALL=C head -n 1 -- "$path" 2>/dev/null | tr -d '\r')"
+            [[ $first_line =~ ^#!.*(bash|dash|/sh|[[:space:]]sh)([[:space:]]|$) ]]
+          }
+
+          join_reasons() {
+            local joined=""
+            local reason
+
+            for reason in "$@"; do
+              if [[ -z $joined ]]; then
+                joined="$reason"
+              else
+                joined="$joined; $reason"
+              fi
+            done
+
+            printf '%s' "$joined"
+          }
+
+          escape_annotation() {
+            local value="$1"
+
+            value="${value//'%'/'%25'}"
+            value="${value//$'\r'/'%0D'}"
+            value="${value//$'\n'/'%0A'}"
+            printf '%s' "$value"
+          }
+
+          flagged_count=0
+          while IFS= read -r file || [[ -n $file ]]; do
+            [[ -z $file ]] && continue
+
+            reasons=()
+
+            [[ $file == *.sh ]] && reasons+=(".sh file")
+            is_execution_sensitive_path "$file" && reasons+=("execution-sensitive path")
+            has_shell_shebang "$file" && reasons+=("shell shebang")
+
+            if (( ${#reasons[@]} > 0 )); then
+              reason_text="$(join_reasons "${reasons[@]}")"
+              printf '%s\t%s\n' "$file" "$reason_text" >>"$flagged_files"
+              flagged_count=$(( flagged_count + 1 ))
+            fi
+          done <"$changed_files"
+
+          if (( flagged_count == 0 )); then
+            {
+              echo "## Shell Script Security Review"
+              echo
+              echo "No shell-script or execution-sensitive file changes were detected in this PR."
+            } >>"$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          while IFS=$'\t' read -r file reason_text; do
+            warning_message="$(escape_annotation "$file: $reason_text")"
+            echo "::warning title=Shell script security review recommended::$warning_message"
+          done <"$flagged_files"
+
+          {
+            echo "## Shell Script Security Review"
+            echo
+            echo "> Advisory only: this job does not block merging."
+            echo
+            echo "This PR changes files that can execute shell commands or alter CI/install-time behavior. Maintainers should review them before merge."
+            echo
+            echo "| File | Reason |"
+            echo "|---|---|"
+            while IFS=$'\t' read -r file reason_text; do
+              file="${file//|/\\|}"
+              reason_text="${reason_text//|/\\|}"
+              printf '| `%s` | %s |\n' "$file" "$reason_text"
+            done <"$flagged_files"
+            echo
+            echo "Review focus:"
+            echo "- privilege escalation, sudo/pkexec/systemctl use, and persistence hooks"
+            echo "- install-time execution, migrations, login/session startup, and systemd units"
+            echo "- network fetches, curl-pipe-shell patterns, package source changes, and remote code execution"
+            echo "- credential, token, key, SSH, GPG, and environment-variable handling"
+            echo "- obfuscation, encoded payloads, writable PATH assumptions, and unsafe temp-file handling"
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/bin/ryoku-doctor
+++ b/bin/ryoku-doctor
@@ -1,0 +1,272 @@
+#!/bin/bash
+
+set -euo pipefail
+
+script_path="${BASH_SOURCE[0]}"
+script_path="$(readlink -f "$script_path" 2>/dev/null || printf '%s\n' "$script_path")"
+repo_root="$(cd -- "$(dirname -- "$script_path")/.." && pwd)"
+source "$repo_root/lib/runtime-env.sh"
+source "$repo_root/lib/pacman-conflicts.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage: ryoku-doctor [update|-h]
+
+Commands:
+  ff      Fast-forward Ryoku to the latest release branch
+  update  Diagnose the latest failed Ryoku update and apply safe fixes
+
+With no command, ryoku-doctor runs the desktop shell doctor.
+USAGE
+}
+
+state_home() {
+  printf '%s\n' "${XDG_STATE_HOME:-$HOME/.local/state}"
+}
+
+update_status_file() {
+  printf '%s\n' "${RYOKU_UPDATE_STATUS:-$(state_home)/quickshell/user/update-status}"
+}
+
+print_update_status() {
+  local status_file status
+
+  status_file="$(update_status_file)"
+  [[ -r $status_file ]] || return 0
+
+  status="$(<"$status_file")"
+  [[ -n $status ]] || return 0
+
+  echo "Status: $status"
+}
+
+latest_update_log() {
+  ryoku_pacman_latest_update_log
+}
+
+doctor_git() {
+  GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=/bin/true git -C "$RYOKU_PATH" "$@"
+}
+
+doctor_release_branch() {
+  printf '%s\n' "${RYOKU_UPDATE_BRANCH:-main}"
+}
+
+doctor_remote_url() {
+  printf '%s\n' "${RYOKU_UPDATE_REMOTE_URL:-https://github.com/neur0map/ryoku-arch.git}"
+}
+
+doctor_remote_ref() {
+  printf 'origin/%s\n' "$(doctor_release_branch)"
+}
+
+doctor_prepare_remote() {
+  local remote_url
+
+  [[ -d $RYOKU_PATH/.git ]] || return 1
+
+  remote_url="$(doctor_remote_url)"
+  if doctor_git remote get-url origin >/dev/null 2>&1; then
+    doctor_git remote set-url origin "$remote_url"
+  else
+    doctor_git remote add origin "$remote_url"
+  fi
+}
+
+doctor_fetch_release() {
+  local release_branch
+
+  release_branch="$(doctor_release_branch)"
+  doctor_prepare_remote || return 1
+  doctor_git fetch --prune origin "+refs/heads/${release_branch}:refs/remotes/origin/${release_branch}" >/dev/null 2>&1
+}
+
+doctor_fast_forward_available() {
+  local remote_ref
+
+  doctor_fetch_release || return 1
+  remote_ref="$(doctor_remote_ref)"
+  doctor_git rev-parse --verify "$remote_ref" >/dev/null 2>&1 || return 1
+  doctor_git merge-base --is-ancestor HEAD "$remote_ref" || return 1
+  [[ $(doctor_git rev-parse HEAD) != "$(doctor_git rev-parse "$remote_ref")" ]]
+}
+
+doctor_confirm_fast_forward() {
+  local answer
+
+  if [[ ${RYOKU_DOCTOR_ASSUME_YES:-} == "1" ]]; then
+    echo "Fast-forward Ryoku now? [Y/n] y"
+    return 0
+  fi
+
+  if [[ ${RYOKU_DOCTOR_ASSUME_NO:-} == "1" ]]; then
+    echo "Fast-forward Ryoku now? [Y/n] n"
+    return 1
+  fi
+
+  printf 'Fast-forward Ryoku now? [Y/n] '
+  read -r answer || return 1
+  [[ -z $answer || $answer =~ ^[Yy]$ ]]
+}
+
+run_fast_forward_doctor() {
+  local updater="$RYOKU_PATH/bin/ryoku-update-git"
+  local remote_ref
+
+  if ! doctor_fast_forward_available; then
+    echo "Ryoku is already on the latest fast-forwardable release."
+    return 0
+  fi
+
+  remote_ref="$(doctor_remote_ref)"
+  echo "Fast-forwarding Ryoku to $remote_ref..."
+
+  if [[ -x $updater ]]; then
+    "$updater"
+  else
+    doctor_git merge --ff-only "$remote_ref"
+  fi
+}
+
+offer_fast_forward_update() {
+  local remote_ref local_commit remote_commit
+
+  doctor_fast_forward_available || return 1
+
+  remote_ref="$(doctor_remote_ref)"
+  local_commit="$(doctor_git rev-parse --short HEAD)"
+  remote_commit="$(doctor_git rev-parse --short "$remote_ref")"
+
+  echo "A newer Ryoku recovery update is available: $local_commit -> $remote_commit"
+  if doctor_confirm_fast_forward; then
+    run_fast_forward_doctor
+    echo
+    exec "$script_path" update
+  fi
+
+  echo "Skipped Ryoku fast-forward."
+  echo
+  return 1
+}
+
+report_log_warnings() {
+  local log="$1"
+  local warnings=0
+
+  if grep -q "Updating linux initcpios" "$log" \
+    && ! grep -q "Initcpio image generation successful" "$log"; then
+    echo "Warning: initramfs generation may have failed. Review the log before restart."
+    ((warnings++)) || true
+  fi
+
+  if grep -Eq 'unable to lock database|/var/lib/pacman/db\.lck' "$log"; then
+    echo "Warning: pacman database lock detected. Retry after package managers stop."
+    ((warnings++)) || true
+  fi
+
+  if grep -Eqi 'invalid or corrupted package|signature.*(unknown trust|invalid|marginal trust)|keyring.*(error|fail|missing)|required key missing|unknown trust' "$log"; then
+    echo "Warning: package signature or keyring issue detected. Try: ryoku-update-keyring"
+    ((warnings++)) || true
+  fi
+
+  return "$warnings"
+}
+
+run_update_doctor() {
+  local log repair_status
+  local fixes=0
+  local safe_to_retry=0
+  local unresolved=0
+  local warnings=0
+
+  echo "Ryoku Doctor: update"
+  echo
+  print_update_status
+  offer_fast_forward_update || true
+
+  if ! log="$(latest_update_log)"; then
+    echo "No readable Ryoku update log was found."
+    echo "Run: ryoku-doctor"
+    return 1
+  fi
+
+  echo "Log: $log"
+  echo
+
+  if ryoku_pacman_conflicts_from_log "$log" | read -r _; then
+    echo "Detected pacman file conflicts."
+    if ryoku_pacman_repair_conflicts_from_log "$log"; then
+      ((fixes++)) || true
+    else
+      repair_status=$?
+      if (( repair_status == 2 )); then
+        ((safe_to_retry++)) || true
+      else
+        ((unresolved++)) || true
+      fi
+    fi
+    echo
+  fi
+
+  if report_log_warnings "$log"; then
+    :
+  else
+    warnings=$?
+  fi
+
+  if (( fixes > 0 || safe_to_retry > 0 )); then
+    echo "Next:"
+    echo "  Run: ryoku-update -y"
+    return 0
+  fi
+
+  if (( unresolved > 0 || warnings > 0 )); then
+    echo
+    echo "No automatic safe fix was applied."
+    echo "Review the note above, then run: ryoku-update -y"
+    return 1
+  fi
+
+  echo "No known auto-fix matched this log."
+  echo "If the update still fails, open an issue with this log: $log"
+  return 1
+}
+
+run_shell_doctor() {
+  local setup
+  local candidates=(
+    "$RYOKU_PATH/shell/setup"
+    "$RYOKU_PATH/setup"
+    "${XDG_CONFIG_HOME:-$HOME/.config}/quickshell/ryoku-shell/setup"
+    "${XDG_CONFIG_HOME:-$HOME/.config}/ryoku-shell/setup"
+  )
+
+  for setup in "${candidates[@]}"; do
+    [[ -x $setup ]] || continue
+    exec "$setup" -y doctor
+  done
+
+  echo "Ryoku shell doctor is unavailable."
+  echo "Checked the installed repo and quickshell config paths."
+  return 1
+}
+
+case "${1:-}" in
+  "")
+    run_shell_doctor
+    ;;
+  ff)
+    run_fast_forward_doctor
+    ;;
+  update)
+    run_update_doctor
+    ;;
+  -h|help)
+    usage
+    ;;
+  *)
+    echo "Unknown command: $1" >&2
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/bin/ryoku-update
+++ b/bin/ryoku-update
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 set -e
-source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)/lib/runtime-env.sh"
+
+script_path="${BASH_SOURCE[0]}"
+script_path="$(readlink -f "$script_path" 2>/dev/null || printf '%s\n' "$script_path")"
+source "$(cd -- "$(dirname -- "$script_path")/.." && pwd)/lib/runtime-env.sh"
 
 if [[ -z ${RYOKU_UPDATE_INHIBITED:-} ]] && command -v systemd-inhibit >/dev/null 2>&1; then
   exec env RYOKU_UPDATE_INHIBITED=1 systemd-inhibit \
@@ -19,7 +22,12 @@ if [[ -z $RYOKU_UPDATE_LOGGED ]]; then
   exec env RYOKU_UPDATE_LOGGED=1 script -qefc "$script_command" "/tmp/ryoku-update.log"
 fi
 
-trap 'echo ""; echo -e "\033[0;31mSomething went wrong during the update!\n\nPlease review the output above carefully, correct the error, and retry the update.\n\nIf you need assistance, open an issue at https://github.com/neur0map/ryoku-arch/issues\033[0m"' ERR
+update_failed() {
+  echo ""
+  echo -e "\033[0;31mSomething went wrong during the update!\n\nPlease review the output above carefully, correct the error, and retry the update.\n\nRun: ryoku-doctor update\n\nIf you need assistance, open an issue at https://github.com/neur0map/ryoku-arch/issues\033[0m"
+}
+
+trap update_failed ERR
 
 if [[ -z ${RYOKU_UPDATE_POWER_CHECKED:-} ]]; then
   battery_level=""

--- a/bin/ryoku-update-system-pkgs
+++ b/bin/ryoku-update-system-pkgs
@@ -1,24 +1,28 @@
 #!/bin/bash
 
 set -e
-source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)/lib/runtime-env.sh"
 
-move_unowned_node_module() {
-  local package="$1"
-  local node_modules_dir="${RYOKU_SYSTEM_NODE_MODULES_DIR:-/usr/lib/node_modules}"
-  local path="$node_modules_dir/$package"
-  local backup_root="${RYOKU_PACMAN_CONFLICT_BACKUP_DIR:-/var/lib/ryoku/pacman-conflict-backups}"
-  local backup_path="$backup_root/${package}-$(date +%Y%m%d%H%M%S)"
+script_path="${BASH_SOURCE[0]}"
+script_path="$(readlink -f "$script_path" 2>/dev/null || printf '%s\n' "$script_path")"
+repo_root="$(cd -- "$(dirname -- "$script_path")/.." && pwd)"
+source "$repo_root/lib/runtime-env.sh"
+source "$repo_root/lib/pacman-conflicts.sh"
 
-  [[ -e $path ]] || return 0
-  pacman -Q "$package" >/dev/null 2>&1 && return 0
-  pacman -Qo "$path" >/dev/null 2>&1 && return 0
+repair_recent_pacman_conflicts() {
+  local log repair_status
 
-  echo "Moving unowned package-manager conflict: $path -> $backup_path"
-  sudo mkdir -p "$backup_root"
-  sudo mv "$path" "$backup_path"
+  log="$(ryoku_pacman_latest_update_log 2>/dev/null || true)"
+  [[ -n $log ]] || return 0
+
+  if ryoku_pacman_repair_conflicts_from_log "$log"; then
+    return 0
+  else
+    repair_status=$?
+    (( repair_status == 1 || repair_status == 2 )) && return 0
+    return "$repair_status"
+  fi
 }
 
 echo -e "\e[32m\nUpdate system packages\e[0m"
-move_unowned_node_module semver
+repair_recent_pacman_conflicts
 sudo pacman -Syu --noconfirm

--- a/lib/pacman-conflicts.sh
+++ b/lib/pacman-conflicts.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+ryoku_pacman_latest_update_log() {
+  local env_log="${RYOKU_UPDATE_LOG:-}"
+  local state_home="${XDG_STATE_HOME:-$HOME/.local/state}"
+  local candidate newest=""
+  local mtime newest_mtime=0
+  local candidates=(
+    "$state_home/quickshell/user/update.log"
+    "$state_home/ryoku/update.log"
+    "/tmp/ryoku-update.log"
+    "/tmp/omarchy-update.log"
+  )
+
+  if [[ -n $env_log && -r $env_log ]]; then
+    printf '%s\n' "$env_log"
+    return 0
+  fi
+
+  for candidate in "${candidates[@]}"; do
+    [[ -r $candidate ]] || continue
+
+    mtime=$(stat -c %Y "$candidate" 2>/dev/null || printf '0')
+    if [[ -z $newest ]] || (( mtime > newest_mtime )); then
+      newest="$candidate"
+      newest_mtime="$mtime"
+    fi
+  done
+
+  [[ -n $newest ]] || return 1
+  printf '%s\n' "$newest"
+}
+
+ryoku_pacman_map_conflict_path() {
+  local path="$1"
+  local node_modules_dir="${RYOKU_SYSTEM_NODE_MODULES_DIR:-}"
+
+  if [[ -n $node_modules_dir && $path == /usr/lib/node_modules/* ]]; then
+    printf '%s/%s\n' "$node_modules_dir" "${path#/usr/lib/node_modules/}"
+  else
+    printf '%s\n' "$path"
+  fi
+}
+
+ryoku_pacman_conflicts_from_log() {
+  local log="$1"
+  local line package path
+
+  [[ -r $log ]] || return 1
+
+  while IFS= read -r line; do
+    line="${line//$'\r'/}"
+    if [[ $line =~ ^([^:]+):[[:space:]]+(/.*)[[:space:]]exists[[:space:]]in[[:space:]]filesystem$ ]]; then
+      package="${BASH_REMATCH[1]}"
+      path="${BASH_REMATCH[2]}"
+      printf '%s\t%s\n' "$package" "$path"
+    fi
+  done < "$log"
+}
+
+ryoku_pacman_safe_label() {
+  local label="$1"
+
+  label="${label//\//_}"
+  label="${label// /_}"
+  printf '%s\n' "$label"
+}
+
+ryoku_pacman_repair_conflict_path() {
+  local package="$1"
+  local path="$2"
+  local backup_root="${RYOKU_PACMAN_CONFLICT_BACKUP_DIR:-/var/lib/ryoku/pacman-conflict-backups}"
+  local label backup_path
+
+  label="$(ryoku_pacman_safe_label "$package")"
+  backup_path="$backup_root/${label}-$(date +%Y%m%d%H%M%S)/${path#/}"
+
+  if [[ ! -e $path ]]; then
+    echo "Known conflict path is already clear: $path"
+    return 2
+  fi
+
+  if pacman -Qo "$path" >/dev/null 2>&1; then
+    echo "Path is owned by pacman, leaving it in place: $path"
+    return 2
+  fi
+
+  echo "Moving unowned package-manager conflict: $path -> $backup_path"
+  sudo mkdir -p "$(dirname "$backup_path")"
+  sudo mv "$path" "$backup_path"
+}
+
+ryoku_pacman_repair_conflicts_from_log() {
+  local log="$1"
+  local package raw_path path repair_status
+  local found=0
+  local fixes=0
+  local clear=0
+  local unresolved=0
+
+  while IFS=$'\t' read -r package raw_path; do
+    [[ -n ${package:-} && -n ${raw_path:-} ]] || continue
+
+    found=1
+    path="$(ryoku_pacman_map_conflict_path "$raw_path")"
+
+    if ryoku_pacman_repair_conflict_path "$package" "$path"; then
+      ((fixes++)) || true
+    else
+      repair_status=$?
+      if (( repair_status == 2 )); then
+        ((clear++)) || true
+      else
+        ((unresolved++)) || true
+      fi
+    fi
+  done < <(ryoku_pacman_conflicts_from_log "$log")
+
+  (( fixes > 0 )) && return 0
+  (( found == 0 )) && return 1
+  (( unresolved == 0 && clear > 0 )) && return 2
+  return 1
+}

--- a/migrations/1778560467.sh
+++ b/migrations/1778560467.sh
@@ -1,0 +1,13 @@
+echo "Expose Ryoku update recovery commands in the user launcher path"
+
+bin_dir="${XDG_BIN_HOME:-$HOME/.local/bin}"
+mkdir -p "$bin_dir"
+
+for command in ryoku-update ryoku-doctor; do
+  source_path="$RYOKU_PATH/bin/$command"
+  target_path="$bin_dir/$command"
+
+  [[ -x $source_path ]] || continue
+  ln -sf "$source_path" "$target_path"
+  echo "Linked $target_path"
+done

--- a/shell/services/ShellUpdates.qml
+++ b/shell/services/ShellUpdates.qml
@@ -263,6 +263,7 @@ Singleton {
             "else " +
                 "echo \"failed:$rc\" > '" + statusPath + "'; " +
                 "echo \"Something went wrong (exit $rc). Check the output above for details.\"; " +
+                "echo 'Run: ryoku-doctor update'; " +
                 "echo 'You can close this window whenever you want.'; " +
             "fi; " +
             "read -r _"
@@ -404,7 +405,7 @@ Singleton {
 
                 if (status.startsWith("failed")) {
                     const code = status.split(":")[1] || "unknown"
-                    root.lastError = "Last update failed (exit " + code + "). Check " + Directories.updateLogPath + " for details."
+                    root.lastError = "Last update failed (exit " + code + "). Check " + Directories.updateLogPath + " for details. Run: ryoku-doctor update."
                     print("[ShellUpdates] Detected failed update from previous shell: exit " + code)
                     clearStatusFileProc.running = true
                     return
@@ -1231,14 +1232,14 @@ Singleton {
                     const parts = status.split(":")
                     const code = parts.length > 1 ? parts[1] : "unknown"
                     root.clearUpdateProgressUi()
-                    root.lastError = "Update failed (exit " + code + "). Check " + Directories.updateLogPath + " for details."
+                    root.lastError = "Update failed (exit " + code + "). Check " + Directories.updateLogPath + " for details. Run: ryoku-doctor update."
                     clearStatusFileProc.running = true
                     print("[ShellUpdates] Update FAILED with exit code " + code)
                 } else if (status.startsWith("progress:")) {
                     if (status === root._lastWatchdogStatus) {
                         // Same progress marker seen twice — update is stuck
                         root.clearUpdateProgressUi()
-                        root.lastError = "Update stuck at: " + status.split(":").slice(3).join(":") + ". Check " + Directories.updateLogPath + " for details."
+                        root.lastError = "Update stuck at: " + status.split(":").slice(3).join(":") + ". Check " + Directories.updateLogPath + " for details. Run: ryoku-doctor update."
                         clearStatusFileProc.running = true
                         print("[ShellUpdates] Update stuck — same progress seen twice: " + status)
                     } else {
@@ -1250,7 +1251,7 @@ Singleton {
                 } else if (status === "updating") {
                     // Still running after 120s — likely stuck
                     root.clearUpdateProgressUi()
-                    root.lastError = "Update appears stuck. Check " + Directories.updateLogPath + " for details."
+                    root.lastError = "Update appears stuck. Check " + Directories.updateLogPath + " for details. Run: ryoku-doctor update."
                     clearStatusFileProc.running = true
                     print("[ShellUpdates] Update appears stuck (still 'updating' after watchdog)")
                 } else if (status === "success") {
@@ -1261,7 +1262,7 @@ Singleton {
                 } else {
                     // Empty or unexpected — assume failed
                     root.clearUpdateProgressUi()
-                    root.lastError = "Update outcome unknown. Check " + Directories.updateLogPath + " for details."
+                    root.lastError = "Update outcome unknown. Check " + Directories.updateLogPath + " for details. Run: ryoku-doctor update."
                     clearStatusFileProc.running = true
                     print("[ShellUpdates] Update status unclear: '" + status + "'")
                 }

--- a/tests/niri-shell-merge-readiness.sh
+++ b/tests/niri-shell-merge-readiness.sh
@@ -84,6 +84,7 @@ aur_packages="install/ryoku-aur.packages"
 
 assert_file "$base_packages"
 assert_file "$aur_packages"
+assert_file "lib/pacman-conflicts.sh"
 
 removed_packages=(
   elephant
@@ -350,6 +351,7 @@ assert_executable bin/ryoku-session-recover
 assert_executable bin/ryoku-cmd-profile-list
 assert_executable bin/ryoku-cmd-profile-status
 assert_executable bin/ryoku-install-profile
+assert_executable bin/ryoku-doctor
 assert_executable bin/ryoku-update-system-pkgs
 assert_executable bin/ryoku-shell-cleanup-orphans
 assert_executable bin/ryoku-refresh-limine
@@ -369,16 +371,19 @@ bash -n bin/ryoku-session-recover
 bash -n bin/ryoku-cmd-profile-list
 bash -n bin/ryoku-cmd-profile-status
 bash -n bin/ryoku-install-profile
+bash -n bin/ryoku-doctor
 bash -n install/profiles/lib.sh
 bash -n bin/ryoku-update-system-pkgs
 bash -n bin/ryoku-shell-cleanup-orphans
 bash -n bin/ryoku-refresh-limine
+bash -n lib/pacman-conflicts.sh
 bash -n bin/ryoku-ipc
 bash -n bin/ryoku-lock-screen
 bash -n bin/ryoku-theme-set-shell
 bash -n bin/ryoku-system-logout
 bash -n bin/ryoku-sddm-autologin
 bash -n bin/ryoku-refresh-sddm
+bash -n migrations/1778560467.sh
 bash -n install/config/shell.sh
 bash -n install/config/session-recover.sh
 bash -n default/systemd/system-sleep/ryoku-session-recover
@@ -394,7 +399,13 @@ assert_contains bin/ryoku-update-perform 'bash "\$RYOKU_INSTALL/packaging/aur-co
 assert_order bin/ryoku-update-perform 'ryoku-update-aur-pkgs' 'packaging/aur-core\.sh' "updates should bootstrap/update AUR access before installing default AUR packages"
 assert_order bin/ryoku-update-perform 'packaging/aur-core\.sh' 'config/shell\.sh' "updates should install default AUR packages before running Ryoku shell setup"
 assert_order bin/ryoku-update-perform 'config/shell\.sh' 'ryoku-migrate' "updates should install or refresh Ryoku shell before migration cleanup"
-assert_contains bin/ryoku-update-system-pkgs 'move_unowned_node_module semver' "system package updates should clear the known unowned semver conflict before pacman -Syu"
+assert_contains bin/ryoku-update 'ryoku-doctor update' "update failures should tell users to run the doctor"
+assert_contains shell/services/ShellUpdates.qml 'ryoku-doctor update' "shell update failures should tell users to run the doctor"
+assert_contains migrations/1778560467.sh 'ryoku-update' "migration should expose ryoku-update in the user launcher path"
+assert_contains migrations/1778560467.sh 'ryoku-doctor' "migration should expose ryoku-doctor in the user launcher path"
+assert_contains bin/ryoku-update-system-pkgs 'ryoku_pacman_repair_conflicts_from_log' "system package updates should clear pacman file conflicts from the latest failed log before pacman -Syu"
+assert_contains lib/pacman-conflicts.sh 'exists.*filesystem' "pacman conflict repair should parse generic pacman file conflict lines"
+assert_not_contains bin/ryoku-update-system-pkgs 'semver|move_unowned_node_module' "system package conflict repair should not be hardcoded to semver"
 assert_contains install/config/shell.sh 'RYOKU_SHELL_PATH' "Ryoku shell installer should support custom install path injection"
 assert_contains install/config/shell.sh 'SHELL_VENDOR' "Ryoku shell installer should reference the vendored shell tree"
 assert_contains install/config/shell.sh 'niri\.service\.wants' "Ryoku installer should wire ryoku-shell.service into niri.service.wants for first login"

--- a/tests/ryoku-doctor-update.sh
+++ b/tests/ryoku-doctor-update.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$tmp/bin" "$tmp/fake-ryoku/bin" "$tmp/conflicts/usr/share/example" "$tmp/backups" "$tmp/state/quickshell/user"
+touch "$tmp/conflicts/usr/share/example/payload.sh"
+
+cat >"$tmp/update.log" <<LOG
+warning: archlinux-keyring-20260420-1 is up to date -- skipping
+error: failed to commit transaction (conflicting files)
+example-tool: $tmp/conflicts/usr/share/example/payload.sh exists in filesystem
+Errors occurred, no packages were upgraded.
+LOG
+
+cat >"$tmp/bin/pacman" <<'PACMAN'
+#!/bin/bash
+
+case "${1:-}" in
+  -Q)
+    exit 0
+    ;;
+  -Qo)
+    exit 1
+    ;;
+esac
+
+exit 2
+PACMAN
+
+cat >"$tmp/bin/sudo" <<'SUDO'
+#!/bin/bash
+
+"$@"
+SUDO
+
+chmod 755 "$tmp/bin/pacman" "$tmp/bin/sudo"
+ln -s "$ROOT_DIR/bin/ryoku-doctor" "$tmp/bin/ryoku-doctor-link"
+ln -s "$ROOT_DIR/bin/ryoku-update" "$tmp/bin/ryoku-update-link"
+
+cat >"$tmp/fake-ryoku/bin/ryoku-update-confirm" <<'CONFIRM'
+#!/bin/bash
+
+exit 1
+CONFIRM
+
+chmod 755 "$tmp/fake-ryoku/bin/ryoku-update-confirm"
+
+"$tmp/bin/ryoku-doctor-link" -h | grep -Fq 'ryoku-doctor [update|-h]' \
+  || fail "ryoku-doctor should resolve its repo root when called through a symlink"
+
+git init -b main "$tmp/source" >/dev/null
+git -C "$tmp/source" config user.email "doctor-test@example.invalid"
+git -C "$tmp/source" config user.name "Doctor Test"
+mkdir -p "$tmp/source/bin"
+cat >"$tmp/source/bin/ryoku-update-git" <<'UPDATE_GIT'
+#!/bin/bash
+
+git -C "$RYOKU_PATH" fetch origin main >/dev/null 2>&1
+git -C "$RYOKU_PATH" merge --ff-only origin/main >/dev/null
+UPDATE_GIT
+chmod 755 "$tmp/source/bin/ryoku-update-git"
+git -C "$tmp/source" add bin/ryoku-update-git
+git -C "$tmp/source" commit -m "base" >/dev/null
+git clone --bare "$tmp/source" "$tmp/remote.git" >/dev/null 2>&1
+git clone "$tmp/remote.git" "$tmp/checkout" >/dev/null 2>&1
+git clone "$tmp/remote.git" "$tmp/checkout-offer" >/dev/null 2>&1
+git -C "$tmp/source" remote add origin "$tmp/remote.git"
+echo "future recovery fix" >"$tmp/source/recovery.txt"
+git -C "$tmp/source" add recovery.txt
+git -C "$tmp/source" commit -m "future recovery fix" >/dev/null
+git -C "$tmp/source" push origin main >/dev/null 2>&1
+
+RYOKU_PATH="$tmp/checkout" \
+RYOKU_UPDATE_REMOTE_URL="$tmp/remote.git" \
+  "$ROOT_DIR/bin/ryoku-doctor" ff >/dev/null \
+  || fail "ryoku-doctor ff should fast-forward to the latest release branch"
+git -C "$tmp/checkout" merge-base --is-ancestor origin/main HEAD \
+  || fail "ryoku-doctor ff should leave checkout at origin/main"
+
+RYOKU_UPDATE_INHIBITED=1 \
+RYOKU_UPDATE_LOGGED=1 \
+RYOKU_UPDATE_POWER_CHECKED=1 \
+RYOKU_PATH="$tmp/fake-ryoku" \
+PATH="$tmp/bin:$PATH" \
+  "$tmp/bin/ryoku-update-link" \
+  || fail "ryoku-update should resolve its repo root when called through a symlink"
+
+output=$(
+  RYOKU_PATH="$tmp/checkout-offer" \
+  RYOKU_UPDATE_REMOTE_URL="$tmp/remote.git" \
+  RYOKU_DOCTOR_ASSUME_NO=1 \
+  RYOKU_UPDATE_LOG="$tmp/update.log" \
+  RYOKU_PACMAN_CONFLICT_BACKUP_DIR="$tmp/backups" \
+  XDG_STATE_HOME="$tmp/state" \
+  PATH="$tmp/bin:$PATH" \
+    "$ROOT_DIR/bin/ryoku-doctor" update 2>&1
+) || fail "ryoku-doctor update should repair generic pacman file conflicts: $output"
+
+[[ ! -e $tmp/conflicts/usr/share/example/payload.sh ]] \
+  || fail "doctor should move an unowned generic conflict file"
+find "$tmp/backups" -path '*/payload.sh' -print -quit | grep -q . \
+  || fail "doctor should preserve moved generic conflict files"
+grep -Fq 'Detected pacman file conflicts.' <<<"$output" \
+  || fail "doctor should identify generic pacman file conflicts"
+grep -Fq 'A newer Ryoku recovery update is available' <<<"$output" \
+  || fail "doctor should offer a fast-forward when a newer release is available"
+grep -Fq 'Fast-forward Ryoku now? [Y/n] n' <<<"$output" \
+  || fail "doctor should allow users to skip the fast-forward"
+grep -Fq 'Run: ryoku-update -y' <<<"$output" \
+  || fail "doctor should tell users the short retry command"
+if grep -Fq 'package signature or keyring issue' <<<"$output"; then
+  fail "doctor should not warn on normal archlinux-keyring update lines"
+fi
+
+echo "PASS: ryoku-doctor update repairs generic pacman conflict"
+
+rm -rf "$tmp/conflicts" "$tmp/backups"
+mkdir -p "$tmp/conflicts/usr/lib/node_modules/semver/functions" "$tmp/backups"
+touch "$tmp/conflicts/usr/lib/node_modules/semver/functions/truncate.js"
+
+cat >"$tmp/update.log" <<LOG
+error: failed to commit transaction (conflicting files)
+semver: /usr/lib/node_modules/semver/functions/truncate.js exists in filesystem
+Errors occurred, no packages were upgraded.
+LOG
+
+cat >"$tmp/bin/pacman" <<'PACMAN'
+#!/bin/bash
+
+case "${1:-}" in
+  -Q)
+    [[ ${2:-} == "semver" ]] && exit 0
+    exit 1
+    ;;
+  -Qo)
+    [[ ${2:-} == "$RYOKU_SYSTEM_NODE_MODULES_DIR/semver" ]] && exit 0
+    [[ ${2:-} == "$RYOKU_SYSTEM_NODE_MODULES_DIR/semver/functions/truncate.js" ]] && exit 1
+    exit 1
+    ;;
+esac
+
+exit 2
+PACMAN
+
+output=$(
+  RYOKU_PATH="$tmp/fake-ryoku" \
+  RYOKU_UPDATE_LOG="$tmp/update.log" \
+  RYOKU_SYSTEM_NODE_MODULES_DIR="$tmp/conflicts/usr/lib/node_modules" \
+  RYOKU_PACMAN_CONFLICT_BACKUP_DIR="$tmp/backups" \
+  XDG_STATE_HOME="$tmp/state" \
+  PATH="$tmp/bin:$PATH" \
+    "$ROOT_DIR/bin/ryoku-doctor" update 2>&1
+) || fail "ryoku-doctor update should repair an unowned file inside pacman-owned semver: $output"
+
+[[ -d $tmp/conflicts/usr/lib/node_modules/semver ]] || fail "doctor should not move pacman-owned semver directory"
+[[ ! -e $tmp/conflicts/usr/lib/node_modules/semver/functions/truncate.js ]] \
+  || fail "doctor should move unowned conflict files inside pacman-owned semver"
+find "$tmp/backups" -path '*/truncate.js' -print -quit | grep -q . \
+  || fail "doctor should preserve the moved semver conflict file"
+grep -Fq 'Run: ryoku-update -y' <<<"$output" \
+  || fail "doctor should still tell users the short retry command"
+
+echo "PASS: ryoku-doctor update repairs owned semver file conflict"
+
+rm -rf "$tmp/conflicts" "$tmp/backups"
+mkdir -p "$tmp/conflicts/usr/lib/node_modules/semver/functions" "$tmp/backups"
+touch "$tmp/conflicts/usr/lib/node_modules/semver/functions/truncate.js"
+
+cat >"$tmp/bin/pacman" <<'PACMAN'
+#!/bin/bash
+
+case "${1:-}" in
+  -Q|-Qo)
+    exit 0
+    ;;
+esac
+
+exit 2
+PACMAN
+
+output=$(
+  RYOKU_PATH="$tmp/fake-ryoku" \
+  RYOKU_UPDATE_LOG="$tmp/update.log" \
+  RYOKU_SYSTEM_NODE_MODULES_DIR="$tmp/conflicts/usr/lib/node_modules" \
+  RYOKU_PACMAN_CONFLICT_BACKUP_DIR="$tmp/backups" \
+  XDG_STATE_HOME="$tmp/state" \
+  PATH="$tmp/bin:$PATH" \
+    "$ROOT_DIR/bin/ryoku-doctor" update 2>&1
+) || fail "ryoku-doctor update should allow retry when conflict paths are already pacman-owned: $output"
+
+[[ -e $tmp/conflicts/usr/lib/node_modules/semver/functions/truncate.js ]] \
+  || fail "doctor should not move pacman-owned conflict files"
+grep -Fq 'Path is owned by pacman, leaving it in place' <<<"$output" \
+  || fail "doctor should report pacman-owned conflict files"
+grep -Fq 'Run: ryoku-update -y' <<<"$output" \
+  || fail "doctor should still tell users to retry when conflict files are already owned"
+
+echo "PASS: ryoku-doctor update handles already-owned semver"

--- a/tests/update-system-pkgs-conflicts.sh
+++ b/tests/update-system-pkgs-conflicts.sh
@@ -12,14 +12,20 @@ fail() {
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
-mkdir -p "$tmp/bin" "$tmp/node_modules/semver/functions" "$tmp/backups"
-touch "$tmp/node_modules/semver/functions/truncate.js"
+mkdir -p "$tmp/bin" "$tmp/conflicts/usr/share/example" "$tmp/backups"
+touch "$tmp/conflicts/usr/share/example/payload.sh"
+
+cat >"$tmp/update.log" <<LOG
+error: failed to commit transaction (conflicting files)
+example-tool: $tmp/conflicts/usr/share/example/payload.sh exists in filesystem
+Errors occurred, no packages were upgraded.
+LOG
 
 cat >"$tmp/bin/pacman" <<'PACMAN'
 #!/bin/bash
 
 case "${1:-}" in
-  -Q|-Qo)
+  -Qo)
     exit 1
     ;;
   -Syu)
@@ -40,16 +46,64 @@ SUDO
 chmod 755 "$tmp/bin/pacman" "$tmp/bin/sudo"
 
 RYOKU_PATH="$ROOT_DIR" \
-RYOKU_SYSTEM_NODE_MODULES_DIR="$tmp/node_modules" \
+RYOKU_UPDATE_LOG="$tmp/update.log" \
 RYOKU_PACMAN_CONFLICT_BACKUP_DIR="$tmp/backups" \
 RYOKU_TEST_PACMAN_UPDATE="$tmp/pacman-update" \
 PATH="$tmp/bin:$PATH" \
   "$ROOT_DIR/bin/ryoku-update-system-pkgs"
 
-[[ ! -e $tmp/node_modules/semver ]] || fail "unowned semver tree should be moved before pacman update"
-find "$tmp/backups" -path '*/semver-*/functions/truncate.js' -print -quit | grep -q . \
-  || fail "unowned semver tree should be preserved in conflict backups"
+[[ ! -e $tmp/conflicts/usr/share/example/payload.sh ]] \
+  || fail "generic unowned conflict file should be moved before pacman update"
+find "$tmp/backups" -path '*/payload.sh' -print -quit | grep -q . \
+  || fail "generic unowned conflict file should be preserved in conflict backups"
 grep -Fx -- "-Syu --noconfirm" "$tmp/pacman-update" >/dev/null \
   || fail "system package update should still run after conflict cleanup"
 
-echo "PASS: update system package conflict cleanup"
+echo "PASS: update system package generic file conflict cleanup"
+
+rm -rf "$tmp/conflicts" "$tmp/backups"
+mkdir -p "$tmp/conflicts/usr/lib/node_modules/semver/functions" "$tmp/backups"
+touch "$tmp/conflicts/usr/lib/node_modules/semver/functions/truncate.js"
+
+cat >"$tmp/update.log" <<'LOG'
+error: failed to commit transaction (conflicting files)
+semver: /usr/lib/node_modules/semver/functions/truncate.js exists in filesystem
+Errors occurred, no packages were upgraded.
+LOG
+
+cat >"$tmp/bin/pacman" <<'PACMAN'
+#!/bin/bash
+
+case "${1:-}" in
+  -Qo)
+    [[ ${2:-} == "$RYOKU_SYSTEM_NODE_MODULES_DIR/semver" ]] && exit 0
+    [[ ${2:-} == "$RYOKU_SYSTEM_NODE_MODULES_DIR/semver/functions/truncate.js" ]] && exit 1
+    exit 1
+    ;;
+  -Syu)
+    printf '%s\n' "$*" >"$RYOKU_TEST_PACMAN_UPDATE"
+    exit 0
+    ;;
+esac
+
+exit 2
+PACMAN
+
+RYOKU_PATH="$ROOT_DIR" \
+RYOKU_UPDATE_LOG="$tmp/update.log" \
+RYOKU_SYSTEM_NODE_MODULES_DIR="$tmp/conflicts/usr/lib/node_modules" \
+RYOKU_PACMAN_CONFLICT_BACKUP_DIR="$tmp/backups" \
+RYOKU_TEST_PACMAN_UPDATE="$tmp/pacman-update" \
+PATH="$tmp/bin:$PATH" \
+  "$ROOT_DIR/bin/ryoku-update-system-pkgs"
+
+[[ -d $tmp/conflicts/usr/lib/node_modules/semver ]] \
+  || fail "owned semver package directory should stay in place"
+[[ ! -e $tmp/conflicts/usr/lib/node_modules/semver/functions/truncate.js ]] \
+  || fail "unowned semver conflict file should be moved before pacman update"
+find "$tmp/backups" -path '*/truncate.js' -print -quit | grep -q . \
+  || fail "unowned semver conflict file should be preserved in conflict backups"
+grep -Fx -- "-Syu --noconfirm" "$tmp/pacman-update" >/dev/null \
+  || fail "system package update should still run after owned-package conflict cleanup"
+
+echo "PASS: update system package owned semver file conflict cleanup"


### PR DESCRIPTION
## Summary

Adds a recovery path for broken Ryoku updates:

- introduces `ryoku-doctor update` and `ryoku-doctor ff`
- offers a fast-forward to the latest release branch before applying local log repairs
- parses generic pacman `exists in filesystem` conflicts from failed update logs and moves only unowned conflict paths into backups
- exposes `ryoku-update` and `ryoku-doctor` through the user launcher path with a migration
- points update failure messages at `ryoku-doctor update`
- adds a warning-only PR shell script security alert workflow

## Root Cause

The previous recovery logic was too narrow. It treated the live semver issue as if the package directory ownership was enough, but pacman was blocked by an unowned file inside an otherwise owned package tree. Also, doctor had no self-update/fast-forward lane, so it could not pick up newer recovery fixes before trying local repairs.

## Validation

- `bash tests/ryoku-doctor-update.sh`
- `bash tests/update-system-pkgs-conflicts.sh`
- `bash tests/niri-shell-merge-readiness.sh`
- `bash -n bin/ryoku-doctor bin/ryoku-update bin/ryoku-update-system-pkgs lib/pacman-conflicts.sh migrations/1778560467.sh tests/ryoku-doctor-update.sh tests/update-system-pkgs-conflicts.sh tests/niri-shell-merge-readiness.sh`
- `git diff --check`
