### PR TITLE
Fix unstable-dev update channel switching

### DIFF
--- a/bin/ryoku-branch-set
+++ b/bin/ryoku-branch-set
@@ -5,15 +5,18 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)/lib/runtime-env.s
 # Set the branch for Ryoku's git repository.
 
 if (($# == 0)); then
-  echo "Usage: ryoku-branch-set main"
+  echo "Usage: ryoku-branch-set main|unstable-dev"
   exit 1
 else
   branch="$1"
 fi
 
-if [[ $branch != "main" ]]; then
-  echo "Error: Invalid branch '$branch'. Must be: main"
+case "$branch" in
+main | unstable-dev) ;;
+*)
+  echo "Error: Invalid branch '$branch'. Must be: main or unstable-dev"
   exit 1
-fi
+  ;;
+esac
 
 git -C "$RYOKU_PATH" switch "$branch"

--- a/bin/ryoku-channel-current
+++ b/bin/ryoku-channel-current
@@ -2,8 +2,8 @@
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)/lib/runtime-env.sh"
 
-# Print the active Ryoku release channel. Defaults to "main" on absence.
-# Legacy channel names are collapsed to main.
+# Print the active Ryoku update channel. Defaults to "main" on absence.
+# Unknown legacy channel names are collapsed to main.
 
 STATE_FILE="$RYOKU_STATE_PATH/channel"
 
@@ -14,6 +14,6 @@ else
 fi
 
 case "$channel" in
-main) echo "$channel" ;;
+main | unstable-dev) echo "$channel" ;;
 *) echo "main" ;;
 esac

--- a/bin/ryoku-channel-set
+++ b/bin/ryoku-channel-set
@@ -1,28 +1,25 @@
 #!/bin/bash
 
+set -e
+
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)/lib/runtime-env.sh"
 
-# Set the Ryoku channel. Ryoku ships one public channel: main.
+# Set the Ryoku update channel. Pacman packages still use the main mirror.
 
 if (($# == 0)); then
-  echo "Usage: ryoku-channel-set main"
+  echo "Usage: ryoku-channel-set main|unstable-dev"
   exit 1
 fi
 
 channel="$1"
 
 case "$channel" in
-main) ;;
+main | unstable-dev) ;;
 *)
   echo "Unknown channel: $channel"
   exit 1
   ;;
 esac
 
-mkdir -p "$RYOKU_STATE_PATH"
-printf '%s\n' "$channel" >"$RYOKU_STATE_PATH/channel"
-
-ryoku-branch-set "main"
 ryoku-refresh-pacman "main"
-
-ryoku-update -y
+ryoku-update-branch "$channel"

--- a/bin/ryoku-migrate
+++ b/bin/ryoku-migrate
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+script_path="${BASH_SOURCE[0]}"
+script_path="$(readlink -f "$script_path" 2>/dev/null || printf '%s\n' "$script_path")"
+repo_root="$(cd -- "$(dirname -- "$script_path")/.." && pwd)"
 source "$repo_root/lib/runtime-env.sh"
 source "$repo_root/lib/update-dashboard.sh"
 

--- a/bin/ryoku-update-branch
+++ b/bin/ryoku-update-branch
@@ -1,18 +1,67 @@
 #!/bin/bash
 
 set -e
+script_path="${BASH_SOURCE[0]}"
+script_path="$(readlink -f "$script_path" 2>/dev/null || printf '%s\n' "$script_path")"
+source "$(cd -- "$(dirname -- "$script_path")/.." && pwd)/lib/runtime-env.sh"
 
 if (($# == 0)); then
-  echo "Usage: ryoku-update-branch main"
+  echo "Usage: ryoku-update-branch main|unstable-dev"
   exit 1
 fi
 
 branch="$1"
 
-if [[ $branch != "main" ]]; then
-  echo "Error: Invalid branch '$branch'. Must be: main"
+case "$branch" in
+main | unstable-dev) ;;
+*)
+  echo "Error: Invalid branch '$branch'. Must be: main or unstable-dev"
   exit 1
-fi
+  ;;
+esac
+
+write_shell_update_channel() {
+  local config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+  local config_file=""
+  local tmp_file=""
+
+  if [[ -n ${RYOKU_SHELL_CONFIG_DIR:-} ]]; then
+    config_file="$RYOKU_SHELL_CONFIG_DIR/config.json"
+  elif [[ -f $config_home/ryoku-shell/config.json ]]; then
+    config_file="$config_home/ryoku-shell/config.json"
+  else
+    config_file="$config_home/ryoku-shell/config.json"
+  fi
+
+  mkdir -p "$(dirname "$config_file")"
+
+  if command -v python3 >/dev/null 2>&1; then
+    tmp_file="$(mktemp)"
+    python3 - "$config_file" "$branch" >"$tmp_file" <<'PY'
+import json
+import sys
+
+path, channel = sys.argv[1], sys.argv[2]
+try:
+    with open(path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+except Exception:
+    data = {}
+
+shell_updates = data.get("shellUpdates")
+if not isinstance(shell_updates, dict):
+    shell_updates = {}
+data["shellUpdates"] = shell_updates
+shell_updates["channel"] = channel
+
+json.dump(data, sys.stdout, indent=2)
+sys.stdout.write("\n")
+PY
+    mv -- "$tmp_file" "$config_file"
+  elif [[ ! -f $config_file ]]; then
+    printf '{"shellUpdates":{"channel":"%s"}}\n' "$branch" >"$config_file"
+  fi
+}
 
 # Snapshot before switching branch
 ryoku-snapshot create || (( $? == 127 ))
@@ -25,7 +74,7 @@ else
 fi
 
 # Switch branches
-git -C "$RYOKU_PATH" switch "$branch"
+RYOKU_UPDATE_BRANCH="$branch" ryoku-update-git
 
 # Reapply stash if we made one
 if [[ $stashed == "true" ]]; then
@@ -36,3 +85,7 @@ fi
 
 # Update the system from the new branch
 ryoku-update-perform
+
+mkdir -p "$RYOKU_STATE_PATH"
+printf '%s\n' "$branch" >"$RYOKU_STATE_PATH/channel"
+write_shell_update_channel

--- a/bin/ryoku-update-perform
+++ b/bin/ryoku-update-perform
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 set -e
-repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+script_path="${BASH_SOURCE[0]}"
+script_path="$(readlink -f "$script_path" 2>/dev/null || printf '%s\n' "$script_path")"
+repo_root="$(cd -- "$(dirname -- "$script_path")/.." && pwd)"
 source "$repo_root/lib/runtime-env.sh"
 source "$repo_root/lib/update-dashboard.sh"
 

--- a/bin/ryoku-update-restart
+++ b/bin/ryoku-update-restart
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+script_path="${BASH_SOURCE[0]}"
+script_path="$(readlink -f "$script_path" 2>/dev/null || printf '%s\n' "$script_path")"
+repo_root="$(cd -- "$(dirname -- "$script_path")/.." && pwd)"
 source "$repo_root/lib/runtime-env.sh"
 source "$repo_root/lib/update-dashboard.sh"
 

--- a/migrations/1778859665.sh
+++ b/migrations/1778859665.sh
@@ -1,4 +1,4 @@
-echo "Collapse Ryoku channel state to main"
+echo "Normalize Ryoku channel state"
 
 STATE_FILE="$HOME/.local/state/ryoku/channel"
 
@@ -8,10 +8,13 @@ else
   current=""
 fi
 
-if [[ $current != "main" ]]; then
+case "$current" in
+main | unstable-dev)
+  echo "  channel already $current"
+  ;;
+*)
   mkdir -p "$(dirname "$STATE_FILE")"
   printf '%s\n' "main" > "$STATE_FILE"
   echo "  channel: main"
-else
-  echo "  channel already main"
-fi
+  ;;
+esac

--- a/tests/channel-main-only.sh
+++ b/tests/channel-main-only.sh
@@ -51,8 +51,6 @@ active_files=(
   bin/ryoku-channel-set
   bin/ryoku-channel-current
   bin/ryoku-refresh-pacman
-  bin/ryoku-branch-set
-  bin/ryoku-update-branch
   bin/ryoku-reinstall-pkgs
   iso/bin/ryoku-iso-make
   iso/bin/ryoku-iso-release
@@ -73,6 +71,17 @@ for path in "${active_files[@]}"; do
   assert_not_contains "$path" '--(rc|dev)([^A-Za-z0-9_-]|$)' "$path should not expose legacy release channel flags"
 done
 
+for path in \
+  bin/ryoku-channel-set \
+  bin/ryoku-channel-current \
+  bin/ryoku-branch-set \
+  bin/ryoku-update-branch; do
+  assert_contains "$path" 'main' "$path should reference the main channel"
+  assert_contains "$path" 'unstable-dev' "$path should expose the unstable-dev update channel"
+  assert_not_contains "$path" 'pacman-(stable|rc|edge)|mirrorlist-(stable|rc|edge)|pacman-online-(stable|rc|edge)' \
+    "$path should not reference legacy pacman channel files"
+done
+
 assert_contains .github/workflows/build-iso.yml 'CHANNEL: main' \
   "workflow should build the installer from the main channel"
 assert_contains .github/workflows/build-iso.yml 'PUBLIC_CHANNEL: stable' \
@@ -81,7 +90,7 @@ assert_not_contains .github/workflows/build-iso.yml 'github\.event\.inputs\.chan
   "workflow should not expose a channel selector"
 assert_not_contains .github/workflows/build-iso.yml 'ryoku/(stable|rc|edge)|ryoku-iso/(stable|rc|edge)' \
   "workflow should not upload to legacy channel paths"
-assert_contains migrations/1778859665.sh 'printf .%s\\n. "main" > "\$STATE_FILE"' \
-  "migration should rewrite legacy channel state to main"
+assert_contains migrations/1778859665.sh 'main | unstable-dev' \
+  "migration should preserve supported update channels"
 
 echo "PASS: tests/channel-main-only.sh"

--- a/tests/channel-switch-state.sh
+++ b/tests/channel-switch-state.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+write_stub() {
+  local path="$1"
+  local body="$2"
+
+  printf '%s\n' '#!/bin/bash' >"$path"
+  printf '%s\n' "$body" >>"$path"
+  chmod +x "$path"
+}
+
+assert_channel() {
+  local state_file="$1"
+  local expected="$2"
+
+  [[ -f $state_file ]] || fail "missing channel state: $state_file"
+  [[ $(<"$state_file") == "$expected" ]] || fail "expected channel $expected, got $(<"$state_file")"
+}
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "$temp_dir"' EXIT
+
+fake_ryoku="$temp_dir/ryoku"
+state_dir="$temp_dir/state"
+config_dir="$temp_dir/config"
+bin_dir="$fake_ryoku/bin"
+
+mkdir -p "$bin_dir" "$state_dir" "$config_dir/ryoku-shell"
+printf '%s\n' "main" >"$state_dir/channel"
+printf '%s\n' '{"shellUpdates":{"channel":"main"}}' >"$config_dir/ryoku-shell/config.json"
+
+write_stub "$bin_dir/ryoku-refresh-pacman" 'exit 1'
+write_stub "$bin_dir/ryoku-update-branch" 'printf "%s\n" "unexpected update branch" >&2; exit 1'
+
+if RYOKU_PATH="$fake_ryoku" RYOKU_STATE_PATH="$state_dir" RYOKU_SHELL_CONFIG_DIR= XDG_CONFIG_HOME="$config_dir" \
+  "$ROOT_DIR/bin/ryoku-channel-set" unstable-dev >/dev/null 2>&1; then
+  fail "channel set should fail when pacman refresh is cancelled"
+fi
+
+assert_channel "$state_dir/channel" "main"
+
+write_stub "$bin_dir/ryoku-snapshot" 'exit 0'
+write_stub "$bin_dir/ryoku-update-git" 'exit 0'
+write_stub "$bin_dir/ryoku-update-perform" 'exit 1'
+write_stub "$bin_dir/git" 'exit 0'
+
+if RYOKU_PATH="$fake_ryoku" RYOKU_STATE_PATH="$state_dir" RYOKU_SHELL_CONFIG_DIR= XDG_CONFIG_HOME="$config_dir" \
+  "$ROOT_DIR/bin/ryoku-update-branch" unstable-dev >/dev/null 2>&1; then
+  fail "update branch should fail when update perform fails"
+fi
+
+assert_channel "$state_dir/channel" "main"
+rg -q '"channel":"main"' "$config_dir/ryoku-shell/config.json" || \
+  fail "shell config channel should remain main after failed switch"
+
+write_stub "$bin_dir/ryoku-update-perform" 'exit 0'
+
+RYOKU_PATH="$fake_ryoku" RYOKU_STATE_PATH="$state_dir" RYOKU_SHELL_CONFIG_DIR= XDG_CONFIG_HOME="$config_dir" \
+  "$ROOT_DIR/bin/ryoku-update-branch" unstable-dev >/dev/null
+
+assert_channel "$state_dir/channel" "unstable-dev"
+rg -q '"channel": "unstable-dev"' "$config_dir/ryoku-shell/config.json" || \
+  fail "shell config channel should update after successful switch"
+
+echo "PASS: channel switch state is committed only after success"


### PR DESCRIPTION
## Summary

Restores `unstable-dev` as a supported Ryoku update channel while keeping pacman on the single `main` package mirror.

## Root Cause

The channel collapse to `main` left `ryoku-channel-set`, `ryoku-channel-current`, `ryoku-branch-set`, and `ryoku-update-branch` rejecting or rewriting `unstable-dev`. The migration also rewrote non-main channel state back to `main`.

A second issue was that channel state was written before the sudo-gated pacman refresh and update path completed. If the user cancelled the sudo password prompt, the GUI could report `unstable-dev` even though the switch did not complete. Separately, symlinked updater entrypoints resolved their repo root from `/usr/local/bin`, causing `ryoku-update-perform` to source a missing `/usr/local/lib/update-dashboard.sh`.

## Changes

- Accept and persist `unstable-dev` in channel and branch helpers.
- Keep pacman refresh pinned to `main`, since package mirror config remains single-channel.
- Commit channel state and shell update config only after the switch/update path succeeds.
- Make `ryoku-update-branch` source `runtime-env.sh` directly for GUI/direct launches.
- Preserve supported channel state in the existing migration.
- Resolve symlinked updater entrypoints through `readlink -f` before sourcing repo-local libraries.
- Add regression coverage for cancelled/failed channel switches.

## Validation

- `bash -n bin/ryoku-channel-set bin/ryoku-channel-current bin/ryoku-branch-set bin/ryoku-update-branch bin/ryoku-update-perform bin/ryoku-update-restart bin/ryoku-migrate migrations/1778859665.sh tests/channel-switch-state.sh`
- `bash tests/channel-switch-state.sh`
- `bash tests/channel-main-only.sh`
- `bash tests/update-git-release-branch.sh`
- `bash tests/update-dashboard.sh`
