### PR TITLE
[codex] Keep games opaque under HyprMod transparency

### DIFF
--- a/config/hypr/hyprland.conf
+++ b/config/hypr/hyprland.conf
@@ -189,3 +189,8 @@ windowrule = match:class ^(org.ryoku.screensaver)$, fullscreen true
 
 # HyprMod managed settings
 source = ~/.config/hypr/hyprland-gui.conf
+
+# Keep games opaque while preserving HyprMod transparency for normal windows.
+windowrule = opacity 1.0 override 1.0 override 1.0 override, match:content game
+windowrule = opacity 1.0 override 1.0 override 1.0 override, match:class ^(steam_app_[0-9]+|gamescope)$
+windowrule = opacity 1.0 override 1.0 override 1.0 override, match:initial_class ^(steam_app_[0-9]+|gamescope)$

--- a/migrations/1779597877.sh
+++ b/migrations/1779597877.sh
@@ -1,0 +1,26 @@
+echo "Keep game windows opaque under HyprMod transparency"
+
+hypr_conf="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/hyprland.conf"
+game_opacity_comment="# Keep games opaque while preserving HyprMod transparency for normal windows."
+game_content_rule="windowrule = opacity 1.0 override 1.0 override 1.0 override, match:content game"
+game_class_rule="windowrule = opacity 1.0 override 1.0 override 1.0 override, match:class ^(steam_app_[0-9]+|gamescope)$"
+game_initial_class_rule="windowrule = opacity 1.0 override 1.0 override 1.0 override, match:initial_class ^(steam_app_[0-9]+|gamescope)$"
+
+if [[ -f $hypr_conf ]]; then
+  tmp_conf=$(mktemp)
+  grep -Fxv "$game_opacity_comment" "$hypr_conf" \
+    | grep -Fxv "$game_content_rule" \
+    | grep -Fxv "$game_class_rule" \
+    | grep -Fxv "$game_initial_class_rule" >"$tmp_conf" || true
+  mv "$tmp_conf" "$hypr_conf"
+
+  printf '\n%s\n%s\n%s\n%s\n' \
+    "$game_opacity_comment" \
+    "$game_content_rule" \
+    "$game_class_rule" \
+    "$game_initial_class_rule" >>"$hypr_conf"
+fi
+
+if command -v hyprctl >/dev/null 2>&1; then
+  hyprctl reload >/dev/null 2>&1 || true
+fi

--- a/tests/hyprmod-persistent-config.sh
+++ b/tests/hyprmod-persistent-config.sh
@@ -19,6 +19,20 @@ assert_contains() {
   grep -Eq "$pattern" "$path" || fail "$message"
 }
 
+assert_contains_fixed() {
+  local path="$1"
+  local needle="$2"
+  local message="$3"
+
+  grep -Fxq "$needle" "$path" || fail "$message"
+}
+
+hyprmod_source_line="source = ~/.config/hypr/hyprland-gui.conf"
+game_opacity_comment="# Keep games opaque while preserving HyprMod transparency for normal windows."
+game_content_rule="windowrule = opacity 1.0 override 1.0 override 1.0 override, match:content game"
+game_class_rule="windowrule = opacity 1.0 override 1.0 override 1.0 override, match:class ^(steam_app_[0-9]+|gamescope)$"
+game_initial_class_rule="windowrule = opacity 1.0 override 1.0 override 1.0 override, match:initial_class ^(steam_app_[0-9]+|gamescope)$"
+
 [[ -f $ROOT_DIR/config/hypr/hyprland-gui.conf ]] || \
   fail "Ryoku should ship HyprMod's managed config target"
 [[ -f $ROOT_DIR/shell/modules/controlcenter/WindowTitle.qml ]] || \
@@ -61,6 +75,15 @@ assert_contains "$ROOT_DIR/config/hypr/hyprland.conf" \
 assert_contains "$ROOT_DIR/config/hypr/hyprland.conf" \
   '^windowrule = match:class \^\(io\.github\.bluemancz\.hyprmod\)\$, center true$' \
   "HyprMod should open centered like Ryoku settings"
+assert_contains_fixed "$ROOT_DIR/config/hypr/hyprland.conf" \
+  "$game_content_rule" \
+  "game content should stay opaque under HyprMod transparency"
+assert_contains_fixed "$ROOT_DIR/config/hypr/hyprland.conf" \
+  "$game_class_rule" \
+  "Steam games should stay opaque even when they do not report game content"
+assert_contains_fixed "$ROOT_DIR/config/hypr/hyprland.conf" \
+  "$game_initial_class_rule" \
+  "Steam games should stay opaque when matching their initial class"
 if grep -Fq 'text: qsTr("Ryoku Settings")' "$ROOT_DIR/shell/modules/controlcenter/WindowTitle.qml"; then
   fail "floating settings title should not duplicate the Ryoku Settings label"
 fi
@@ -70,6 +93,8 @@ fi
 
 migration="$ROOT_DIR/migrations/1779515727.sh"
 [[ -f $migration ]] || fail "missing HyprMod persistence migration"
+game_opacity_migration="$ROOT_DIR/migrations/1779597877.sh"
+[[ -f $game_opacity_migration ]] || fail "missing game opacity migration"
 
 tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT
@@ -112,6 +137,21 @@ center_count=$(grep -Fxc 'windowrule = match:class ^(io.github.bluemancz.hyprmod
 (( center_count == 1 )) || fail "migration should add the HyprMod center rule exactly once"
 grep -Fxq 'general:gaps_in = 2' "$hyprmod_conf" || \
   fail "migration should preserve existing HyprMod-managed settings"
+
+env -u XDG_CONFIG_HOME HOME="$home_dir" RYOKU_PATH="$ROOT_DIR" bash "$game_opacity_migration" >/dev/null
+env -u XDG_CONFIG_HOME HOME="$home_dir" RYOKU_PATH="$ROOT_DIR" bash "$game_opacity_migration" >/dev/null
+
+source_line=$(grep -Fn "$hyprmod_source_line" "$hypr_conf" | head -n1 | cut -d: -f1)
+game_line=$(grep -Fn "$game_content_rule" "$hypr_conf" | head -n1 | cut -d: -f1)
+(( game_line > source_line )) || fail "game opacity rules should be applied after the HyprMod source"
+comment_count=$(grep -Fxc "$game_opacity_comment" "$hypr_conf")
+content_count=$(grep -Fxc "$game_content_rule" "$hypr_conf")
+class_count=$(grep -Fxc "$game_class_rule" "$hypr_conf")
+initial_class_count=$(grep -Fxc "$game_initial_class_rule" "$hypr_conf")
+(( comment_count == 1 )) || fail "game opacity migration should add its comment exactly once"
+(( content_count == 1 )) || fail "game opacity migration should add the content rule exactly once"
+(( class_count == 1 )) || fail "game opacity migration should add the class rule exactly once"
+(( initial_class_count == 1 )) || fail "game opacity migration should add the initial class rule exactly once"
 
 absolute_home="$tmp_dir/absolute-home"
 absolute_hypr="$absolute_home/.config/hypr"


### PR DESCRIPTION
## Summary

- Keep HyprMod global transparency enabled for normal windows while forcing game-like windows back to exact `1.0` opacity.
- Add a migration so existing Ryoku installs get the same rules after the HyprMod-generated config source.
- Extend HyprMod persistence coverage for the default config and migration idempotency.

## Root Cause

HyprMod writes global Hyprland opacity settings into `hyprland-gui.conf`. Steam games like `steam_app_2073850` can report `contentType: none`, so a content-only game rule does not catch them.

## Validation

- `bash -n migrations/1779597877.sh`
- `bash -n tests/hyprmod-persistent-config.sh`
- `bash tests/hyprmod-persistent-config.sh`
- `bash tests/rebirth-hyprland-minimal.sh`
- `bin/ryoku-dev-shellcheck-changed --origin-main`
- pre-push hook ShellCheck on changed shell files
