### PR TITLE
fix(shell-install): build cava-ryoku to provide libcava for the audio visualizer plugin

### DIFF
--- a/shell-install/distros/TEMPLATE.sh
+++ b/shell-install/distros/TEMPLATE.sh
@@ -37,3 +37,10 @@ ryoku_distro_map() {
 ryoku_distro_install() {
   rsi_die "ryoku_distro_install not implemented for this distro"
 }
+
+# ryoku_distro_install_local_pkgs
+#   Build and install any in-tree packages that are not on official repos or
+#   the AUR (e.g. patched forks that provide additional libraries). Called
+#   after ryoku_distro_install so repo deps are already present. No-op on
+#   distros that do not need local builds.
+ryoku_distro_install_local_pkgs() { :; }

--- a/shell-install/distros/arch.sh
+++ b/shell-install/distros/arch.sh
@@ -156,6 +156,64 @@ ryoku_distro_install_full() {
 # rsi_arch_pkg_present NAME -> 0 if installed.
 rsi_arch_pkg_present() { pacman -Qq "$1" >/dev/null 2>&1; }
 
+# rsi_arch_libcava_present -> 0 if libcava.pc is visible to pkg-config.
+rsi_arch_libcava_present() {
+  if command -v pkgconf >/dev/null 2>&1 && pkgconf --exists libcava 2>/dev/null; then
+    return 0
+  fi
+  if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists libcava 2>/dev/null; then
+    return 0
+  fi
+  [[ -f /usr/lib/pkgconfig/libcava.pc ]]
+}
+
+# Build and install cava-ryoku from the in-tree PKGBUILD so the shell plugin
+# can link libcava. Stock `cava` (official repo) is binary-only; it does not
+# ship libcava.so or libcava.pc, so CMake's pkg_check_modules(Cava libcava)
+# fails and the audio visualiser is silently disabled.
+ryoku_distro_install_local_pkgs() {
+  rsi_step "checking for libcava (required by the shell audio visualizer plugin)"
+
+  if rsi_arch_libcava_present; then
+    rsi_ok "libcava already available"
+    return 0
+  fi
+
+  local pkgbuild_dir="$RSI_REPO/distro/arch/cava-ryoku"
+  if [[ ! -f "$pkgbuild_dir/PKGBUILD" ]]; then
+    rsi_warn "cava-ryoku PKGBUILD not found at $pkgbuild_dir; audio visualizer will be disabled"
+    return 0
+  fi
+
+  rsi_step "building cava-ryoku from $pkgbuild_dir (replaces stock cava, adds libcava)"
+
+  if rsi_dry; then
+    rsi_dim "  would: pacman -Rdd cava (if installed, conflicts with cava-ryoku)"
+    rsi_dim "  would: cd $pkgbuild_dir && makepkg --syncdeps --install --noconfirm --needed --clean"
+    return 0
+  fi
+
+  # cava-ryoku declares conflicts=(cava); pre-remove the stock package so
+  # pacman -U does not abort on the conflict.
+  if rsi_arch_pkg_present cava; then
+    rsi_step "removing stock cava (conflicts with cava-ryoku)"
+    sudo pacman -Rdd --noconfirm cava || {
+      rsi_warn "could not remove stock cava; cava-ryoku install may fail"
+    }
+  fi
+
+  (cd "$pkgbuild_dir" && makepkg --syncdeps --install --noconfirm --needed --clean) || {
+    rsi_warn "cava-ryoku build failed; audio visualizer will be disabled (check output above)"
+    return 0
+  }
+
+  if rsi_arch_libcava_present; then
+    rsi_ok "libcava available"
+  else
+    rsi_warn "cava-ryoku installed but libcava.pc not found; plugin build may still fail"
+  fi
+}
+
 ryoku_distro_map() {
   printf '%s' "${RSI_ARCH_PKG[$1]:-}"
 }

--- a/shell-install/install
+++ b/shell-install/install
@@ -59,6 +59,7 @@ rsi_system_update
 rsi_manifest_init
 rsi_backup_setup
 rsi_install_packages
+rsi_install_local_packages
 rsi_deploy
 rsi_verify
 

--- a/shell-install/lib/packages.sh
+++ b/shell-install/lib/packages.sh
@@ -35,3 +35,11 @@ rsi_install_packages() {
   fi
   rsi_ok "dependencies satisfied"
 }
+
+# Build and install in-tree packages that are not on official repos or the AUR
+# (currently: cava-ryoku, which provides libcava needed by the shell plugin).
+# Must run after rsi_install_packages so makedepends are already present.
+rsi_install_local_packages() {
+  rsi_header "Building local packages"
+  ryoku_distro_install_local_pkgs
+}


### PR DESCRIPTION
## Problem

On a stock Arch system, `shell-install/install` fails to build the audio visualizer plugin. The shell plugin's `CMakeLists.txt` calls `pkg_check_modules(Cava libcava)` — when `libcava` is absent it silently compiles a stub, leaving `Audio.cava.values` permanently at all-zeros with no error at runtime. The music visualizer bars are invisibly broken.

**Root cause:** the official Arch `cava` package ships only `/usr/bin/cava`. It does not provide `libcava.so` or `libcava.pc`. The full OS installer handles this via `install/packaging/distro-arch.sh`, but `shell-install` never called that path.

## Fix

**`distros/arch.sh`** — new `ryoku_distro_install_local_pkgs()`: checks if `libcava` is already present via `pkg-config`, pre-removes the conflicting stock `cava`, then builds `cava-ryoku` from the in-tree `distro/arch/cava-ryoku/PKGBUILD` (the LukashonakV fork that ships both the binary and the shared library). Idempotent and non-fatal — if the build fails the install continues with the visualizer disabled.

**`distros/TEMPLATE.sh`** — adds a no-op stub for `ryoku_distro_install_local_pkgs()` so other distro adapters are unaffected.

**`lib/packages.sh`** — adds `rsi_install_local_packages()` wrapper that calls the distro hook.

**`install`** — calls `rsi_install_local_packages` between `rsi_install_packages` and `rsi_deploy`, so `libcava.pc` is present before CMake configures the plugin.

## Tested

Confirmed working: `libcava, version 0.10.7` detected by CMake, all 174 build targets compiled clean, native `.so` plugins installed successfully.