### PR TITLE
[ryoku] cli: don't let untracked files freeze the update channel

### DIFF
--- a/ryoku/cli/internal/updater/channel.go
+++ b/ryoku/cli/internal/updater/channel.go
@@ -103,8 +103,16 @@ func channelUpdate() error {
 	progress.at("channel")
 	progress.logf("Updating Ryoku (channel: %s)", ch)
 	gitFetch(repo, ch)
+	// report what the sync actually did; "Update complete" alone hid a box that
+	// redeployed the same commit every time.
+	before := gitShort(repo, "HEAD")
 	if err := syncChannel(repo, ch); err != nil {
 		return err
+	}
+	if after := gitShort(repo, "HEAD"); after != before {
+		progress.logf("Advanced %s -> %s", before, after)
+	} else {
+		progress.logf("Already on the latest %s commit (%s)", ch, before)
 	}
 
 	progress.at("deploy")
@@ -120,16 +128,25 @@ func channelUpdate() error {
 // on a dev box tracking unstable-dev exactly as it does on main, not only when
 // the branch is named <ch>. A branch that already contains the channel tip
 // (current or ahead) is left alone; a diverged branch keeps its own commits,
-// except the channel branch, which mirrors upstream and is reset onto it. A dirty
-// tree is never touched: the deploy runs on what is checked out.
+// except the channel branch, which mirrors upstream and is reset onto it. Local
+// edits to tracked files are never touched: the deploy runs on what is checked
+// out. Every path that declines to advance logs why, so a skip is not mistaken
+// for a successful update.
 func syncChannel(repo, ch string) error {
 	remote := "refs/remotes/origin/" + ch
 	// No channel ref to track (offline first run, or the branch is gone): deploy
 	// what is checked out rather than guess.
 	if _, err := sys.RunOut("git", "-C", repo, "rev-parse", "--verify", "--quiet", remote); err != nil {
+		progress.logf("No origin/%s to track (offline, or the branch is gone); deploying the checkout as-is", ch)
 		return nil
 	}
-	if dirty, _ := sys.RunOut("git", "-C", repo, "status", "--porcelain"); strings.TrimSpace(dirty) != "" {
+	// untracked files don't block a fast-forward (git refuses one that would
+	// overwrite them, which surfaces as a real error below). Counting them as
+	// dirty froze boxes: one stray build artifact and update redeployed the same
+	// commit forever.
+	if dirty, _ := sys.RunOut("git", "-C", repo, "status", "--porcelain", "--untracked-files=no"); strings.TrimSpace(dirty) != "" {
+		progress.logf("Uncommitted changes in %s; staying on %s (commit or stash them, then update again)",
+			repo, gitShort(repo, "HEAD"))
 		return nil
 	}
 	// HEAD already contains the channel tip (current or ahead): nothing to pull.
@@ -139,7 +156,9 @@ func syncChannel(repo, ch string) error {
 	// HEAD is strictly behind on a straight line: fast-forward onto the channel.
 	if isAncestor(repo, "HEAD", remote) {
 		if err := sys.Run("git", "-C", repo, "merge", "--ff-only", remote); err != nil {
-			return fmt.Errorf("fast-forward to origin/%s failed: %w", ch, err)
+			// usually an untracked file the incoming commits also add; git names it above.
+			return fmt.Errorf("fast-forward to origin/%s failed (see git's message above; "+
+				"move the colliding file out of %s, then update again): %w", ch, repo, err)
 		}
 		return nil
 	}

--- a/ryoku/cli/internal/updater/channel_test.go
+++ b/ryoku/cli/internal/updater/channel_test.go
@@ -263,6 +263,7 @@ func TestChannelUpdateDeploysWithoutFastForwardWhenDirty(t *testing.T) {
 	if err := os.Chmod(filepath.Join(work, "ryoku", "shell", "deploy.sh"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	writeFile(t, filepath.Join(work, "README"), "clean\n")
 	mustGit(t, work, "add", "-A")
 	mustGit(t, work, "commit", "-m", "seed with deploy stub")
 	mustGit(t, work, "push", "origin", "main")
@@ -272,7 +273,7 @@ func TestChannelUpdateDeploysWithoutFastForwardWhenDirty(t *testing.T) {
 	mustGit(t, "", "clone", origin, other)
 	commitPush(t, other, "feature", "x\n", "add feature", "main")
 
-	writeFile(t, filepath.Join(work, "README"), "dirty\n") // uncommitted change
+	writeFile(t, filepath.Join(work, "README"), "dirty\n") // uncommitted edit to a tracked file
 
 	t.Setenv("RYOKU_REPO", work)
 	t.Setenv("RYOKU_CHANNEL", "main")
@@ -541,5 +542,54 @@ func TestUpdateClearsBehindOnDevBranch(t *testing.T) {
 	}
 	if r.Available || r.Behind != 0 || len(r.Updates) != 0 {
 		t.Errorf("after update want up to date, got available=%v behind=%d updates=%d", r.Available, r.Behind, len(r.Updates))
+	}
+}
+
+// Regression: a checkout with untracked files (build output, an app dir copied
+// in from another branch) still fast-forwards. Treating those as "dirty" pinned
+// real boxes to an old commit while `ryoku update` reported success.
+func TestSyncChannelFastForwardsPastUntrackedFiles(t *testing.T) {
+	root := t.TempDir()
+	origin := filepath.Join(root, "origin.git")
+	work := filepath.Join(root, "work")
+	mustGit(t, "", "init", "--bare", "-b", "main", origin)
+	mustGit(t, "", "clone", origin, work)
+	commitPush(t, work, "README", "one\n", "first commit", "main")
+
+	other := filepath.Join(root, "other")
+	mustGit(t, "", "clone", origin, other)
+	commitPush(t, other, "f1", "x\n", "upstream commit", "main")
+	mustGit(t, work, "fetch", "origin", "main")
+	want := strings.TrimSpace(mustGit(t, work, "rev-parse", "refs/remotes/origin/main"))
+
+	writeFile(t, filepath.Join(work, "scratch", "build.out"), "junk\n")
+
+	if err := syncChannel(work, "main"); err != nil {
+		t.Fatalf("syncChannel: %v", err)
+	}
+	if head := strings.TrimSpace(mustGit(t, work, "rev-parse", "HEAD")); head != want {
+		t.Errorf("HEAD = %s, want %s: untracked files must not block the fast-forward", head, want)
+	}
+}
+
+// An untracked file the incoming commits also add is a real conflict: it must
+// fail loudly rather than skip the update in silence.
+func TestSyncChannelErrorsOnUntrackedCollision(t *testing.T) {
+	root := t.TempDir()
+	origin := filepath.Join(root, "origin.git")
+	work := filepath.Join(root, "work")
+	mustGit(t, "", "init", "--bare", "-b", "main", origin)
+	mustGit(t, "", "clone", origin, work)
+	commitPush(t, work, "README", "one\n", "first commit", "main")
+
+	other := filepath.Join(root, "other")
+	mustGit(t, "", "clone", origin, other)
+	commitPush(t, other, "app/new.qml", "upstream\n", "add app", "main")
+	mustGit(t, work, "fetch", "origin", "main")
+
+	writeFile(t, filepath.Join(work, "app", "new.qml"), "mine\n")
+
+	if err := syncChannel(work, "main"); err == nil {
+		t.Fatal("syncChannel: err=nil, want an error when an untracked file collides")
 	}
 }


### PR DESCRIPTION
`syncChannel` read any non-empty `git status --porcelain` as a dirty tree and bailed, untracked files included. One stray build artifact in the checkout was enough to stop it fast-forwarding, so `ryoku update` rebuilt the same commit over and over and still printed "Update complete". Two machines sat pinned to an old commit that way, weeks apart, and only `ryoku status` (still N behind) ever disagreed.

## What changed

- `--untracked-files=no`, so only tracked modifications hold the sync back. Untracked files can't be lost to a fast-forward — git refuses one that would overwrite them, and that refusal is now a real error naming the file instead of a silent skip.
- Every path that declines to advance logs why, rather than returning `nil` in silence. These go through `progress.logf`, so they reach the Hub and the pill too, not just the terminal.
- `channelUpdate` compares HEAD before and after and reports `Advanced <a> -> <b>` or `Already on the latest <ch> commit (<sha>)`.

## Tests

- `TestSyncChannelFastForwardsPastUntrackedFiles` — regression guard for the freeze.
- `TestSyncChannelErrorsOnUntrackedCollision` — a genuine collision must fail loudly.
- `TestChannelUpdateDeploysWithoutFastForwardWhenDirty` was seeding its dirty file as *untracked*, so it pinned the bug rather than the thing its name promises. Its README is committed in setup now, making the edit a tracked one. That miswritten test is why this shipped twice with a green suite.

`TestSyncChannelLeavesDirtyTree` already used a tracked edit and passes unchanged. Full CLI suite green.

Only touches the git-channel path (`ryoku track` boxes and dev checkouts). Nothing here affects the packaged/pacman path or CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ks6ZVYa7N9mtzs84cKY1gv