### PR TITLE
[system] audio: let the session user reach Maono mic controls

### DIFF
--- a/release/CHANGELOG.md
+++ b/release/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+- `ryoku-desktop` ships `system/hardware/audio/70-ryoku-maono.rules` to
+  `/usr/lib/udev/rules.d`, so the vendor HID node on Maono USB mics is reachable
+  by the active-session user. See the system/hardware changelog.
+
 ### Fixed
 - `ryoku-desktop` ships the default-app map to
   `/usr/share/applications/mimeapps.list` instead of the materialized config, so

--- a/release/packages/ryoku-desktop/PKGBUILD
+++ b/release/packages/ryoku-desktop/PKGBUILD
@@ -498,6 +498,11 @@ package() {
   install -Dm644 "$_repo/system/hardware/ddc/60-ryoku-i2c.rules" \
     "$pkgdir/usr/lib/udev/rules.d/60-ryoku-i2c.rules"
 
+  # Maono USB mics: their control features sit on a vendor HID page the kernel
+  # leaves root-only, so uaccess is what lets a control app reach them at all.
+  install -Dm644 "$_repo/system/hardware/audio/70-ryoku-maono.rules" \
+    "$pkgdir/usr/lib/udev/rules.d/70-ryoku-maono.rules"
+
   # Bluetooth tuning: bluez owns /etc/bluetooth/main.conf and BlueZ has no
   # drop-in dir, so Ryoku cannot ship a copy here (pacman file conflict). The
   # ryoku-bluetooth-tune helper (installed by the hardware glob above) sets the

--- a/system/hardware/CHANGELOG.md
+++ b/system/hardware/CHANGELOG.md
@@ -18,6 +18,15 @@
   `ryoku-desktop` PKGBUILD installs the helper via the hardware glob and the rule
   under `polkit-1/rules.d`; the `.install` runs `apply` on install + upgrade, and
   the installer seeds the country from geolocation or the locale.
+- `audio/70-ryoku-maono.rules`: reach the control features on Maono USB mics.
+  The PD400X and its siblings put gain, EQ, compressor, limiter and the monitor
+  mix behind a vendor-defined HID page (usage page `0xFF01`) instead of the audio
+  interface, and the kernel leaves both `/dev/hidraw*` and the raw USB node
+  root-owned, so a control app running as the user cannot open either one. The
+  rule grants the active-session user access (`uaccess`, no group setup), the
+  same pattern as `60-ryoku-i2c.rules`. Shipped to `/usr/lib/udev` by
+  `ryoku-desktop`. The four standard USB-audio controls (mic gain and mute,
+  headphone level and mute) already worked without it.
 - `leds/ryoku-leds`: `RYOKU_LEDS_DISABLE=1` turns the OpenRGB accent sync off.
   `ryoku-leds apply` runs from Hyprland autostart and again from the shell daemon
   on every wallpaper change, and there was no off switch short of forking the

--- a/system/hardware/audio/70-ryoku-maono.rules
+++ b/system/hardware/audio/70-ryoku-maono.rules
@@ -1,0 +1,6 @@
+# Maono USB mics (PD400X, DM30, ...) expose gain, EQ, compressor, limiter and
+# the monitor mix on a vendor-defined HID page rather than the audio interface.
+# The kernel leaves that node root-only, so grant the active-session user access
+# (uaccess, no group setup) and any control app can reach it.
+KERNEL=="hidraw*", ATTRS{idVendor}=="352f", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTR{idVendor}=="352f", TAG+="uaccess"


### PR DESCRIPTION
Maono USB mics (PD400X, DM30, and siblings — all vendor `352f`) expose their
control features on a vendor-defined HID page rather than the audio interface.
From the PD400X's report descriptor:

    05 0c        Usage Page (Consumer)          volume knob / mute button
    06 01 ff     Usage Page (Vendor 0xFF01)     the control channel
      85 4b        Report ID 0x4B, 63-byte in / 63-byte out
      85 54        Report ID 0x54, 10-byte in / 10-byte out

Gain, EQ, compressor, limiter and the monitor mix all live behind that page. The
kernel leaves the nodes root-owned, so nothing running as the user can open them:

    /dev/hidraw2          crw-------  root root
    /dev/bus/usb/003/003  crw-rw-r--  root root   (no write)

Only four controls reach ALSA over standard USB audio — mic gain and mute,
headphone level and mute — and those already work. Everything else is
unreachable, so the mic keeps whatever settings were last written to it from
Windows or the Android app, with no way to change them on Linux.

This ships `70-ryoku-maono.rules`, granting the active-session user access via
`uaccess` with no group setup, matching the pattern `60-ryoku-i2c.rules` already
uses for DDC/CI. Scoped to the vendor ID so it covers the range rather than one
model.

Verified on a PD400X with the exact rule this installs:

    $ getfacl -p /dev/hidraw2
    user::rw-
    user:nero:rw-
    $ ls -la /dev/bus/usb/003/003
    crw-rw-r--+ 1 root root 189, 258

`udevadm verify` passes.

This does not make any control software work by itself — there is no
open-source Maono control app, and Maono Link is Windows/macOS/Android only.
It removes the permission barrier that blocks every approach (Wine, a VM
passing the device through, or a native tool if one ever appears).
