### PR TITLE
[ryoku] Fingerprint unlock v2: lock screen, sudo, sddm

### DIFF
--- a/ryoku/hub/quickshell/pages/LockscreenPage.qml
+++ b/ryoku/hub/quickshell/pages/LockscreenPage.qml
@@ -81,7 +81,54 @@ Item {
         return parts.join("  \u00b7  ");
     }
 
-    Component.onCompleted: { pg.reload(); pg.kreload(); }
+    // ── fingerprint unlock state (fprintd, live) ────────────────────────────
+    // The sensor's lock-screen counterpart of the keyring card above: whether
+    // the grosshack PAM stack offers a touch-to-unlock at the in-session lock,
+    // and enrolment kept inside Settings. Everything reads/writes fprintd as
+    // this user; nothing here touches root PAM files.
+    property bool ffpEnabled: true            // ~/.config/qylock/fingerprint toggle
+    property bool fdaemon: false              // fprintd service reachable
+    property bool fready: false               // a device is present
+    property string fdevice: ""
+    property var ffingers: []                 // enrolled names from fprintd
+    property var fnames: ({})                 // fingerprint name -> user label map
+    property bool floading: true
+    property string ferr: ""
+    property string fpending: ""              // "" | "enroll" | "verify" | "del"
+    property bool foverlay: false             // the enroll/verify modal
+    property string foverlayMode: ""          // "enroll" | "verify"
+    property string fstatus: ""               // live copy from fprintd output
+    property string fresult: ""               // last finished action result
+    property string fterm: ""                 // accumulated terminal output
+    property int fprogress: -1                // -1 unknown, else percent
+    property string fuser: Quickshell.env("USER") || "traveler"
+    // naming flow after successful enroll
+    property string fnewFinger: ""            // finger name just enrolled (from fprintd)
+    property string fnameDraft: ""            // user's draft name for the new finger
+    property bool fnaming: false              // showing the name field after enroll
+
+    readonly property string fStatusLine: {
+        if (pg.floading)
+            return "Checking\u2026";
+        if (!pg.fdaemon)
+            return "fingerprint service is not running";
+        if (!pg.fready)
+            return "no fingerprint device found";
+        var parts = [ pg.fdevice || "sensor" ];
+        if (pg.ffingers.length === 0)
+            parts.push("no fingers enrolled yet");
+        else
+            parts.push(pg.ffingers.length + (pg.ffingers.length === 1 ? " finger" : " fingers") + " enrolled");
+        return parts.join("  \u00b7  ");
+    }
+
+    function ffriendly(finger) {
+        return pg.fnames[finger] || finger.replace(/-/g, " ");
+    }
+
+    property bool settOpen: false
+
+    Component.onCompleted: { pg.reload(); pg.kreload(); pg.freload(); }
 
     function kreload() {
         kstatusProc.running = true;
@@ -127,6 +174,145 @@ Item {
         pg.kpending = pg.kconvertFor;
         ksetProc.command = ["ryoku", "keyring", "set", pg.kconvertFor, "--reset"];
         ksetProc.running = true;
+    }
+
+    // ── fingerprint actions ─────────────────────────────────────────────────
+    function freload() {
+        pg.floading = true;
+        freadProc.running = true;
+        flistProc.running = true;
+        fnamesReadProc.running = true;
+    }
+    function fparseList(text) {
+        var t = text || "";
+        var dev = "";
+        var m = t.match(/Using\s+device\s+(\S+)/i);
+        if (m) dev = m[1];
+        var fingers = [];
+        var lines = t.split("\n");
+        for (var i = 0; i < lines.length; i++) {
+            var s = lines[i].trim();
+            if (s.indexOf("- #") === 0) {
+                var idx = s.indexOf(":", 3);
+                if (idx > -1) fingers.push(s.slice(idx + 1).trim());
+            }
+        }
+        pg.fdevice = dev;
+        pg.ffingers = fingers;
+        pg.fready = t.indexOf("Using device") !== -1 || t.indexOf("Device at") !== -1 || t.indexOf("found ") !== -1;
+        pg.fdaemon = pg.fready && t.trim() !== "" && t.indexOf("no devices") === -1;
+        pg.floading = false;
+    }
+    function ftoggle(v) {
+        pg.ffpEnabled = v;
+        fwriteProc.command = [
+            "bash", "-c",
+            "mkdir -p \"$HOME/.config/qylock\"; printf '%s\\n' " + (v ? "on" : "off") + " > \"$HOME/.config/qylock/fingerprint\""
+        ];
+        fwriteProc.running = true;
+    }
+    function fparseNames(text) {
+        try {
+            pg.fnames = JSON.parse(text || "{}");
+        } catch (e) {
+            pg.fnames = {};
+        }
+    }
+    function fwriteNames() {
+        var json = JSON.stringify(pg.fnames);
+        fnamesWriteProc.command = ["bash", "-c", "mkdir -p \"$HOME/.config/qylock\"; cat > \"$HOME/.config/qylock/fingerprints.json\""];
+        fnamesWriteProc.stdinEnabled = true;
+        fnamesWriteProc.running = true;
+        // Write happens in onStarted
+    }
+    function fstartEnroll() {
+        pg.ferr = "";
+        pg.fresult = "";
+        pg.fprogress = -1;
+        pg.fterm = "";
+        pg.fstatus = "";
+        pg.fpending = "enroll";
+        pg.foverlayMode = "enroll";
+        pg.fnaming = false;
+        pg.fnewFinger = "";
+        pg.fnameDraft = "";
+        pg.foverlay = true;
+        fenrollProc.command = ["fprintd-enroll"];
+        fenrollProc.running = true;
+    }
+    function fstartVerify(finger) {
+        pg.ferr = "";
+        pg.fresult = "";
+        pg.fprogress = -1;
+        pg.fterm = "";
+        pg.fstatus = "";
+        pg.fpending = "verify";
+        pg.foverlayMode = "verify";
+        pg.foverlay = true;
+        var cmd = ["fprintd-verify"];
+        if (finger !== "")
+            cmd.push("-f", finger);
+        fverifyProc.command = cmd;
+        fverifyProc.running = true;
+    }
+    function fdelete(finger) {
+        pg.ferr = "";
+        pg.fpending = "del";
+        fdelProc.command = ["fprintd-delete", pg.fuser].concat(finger ? ["-f", finger] : []);
+        fdelProc.running = true;
+    }
+    function fcloseOverlay() {
+        if (pg.fpending === "enroll")
+            fenrollProc.signal(15);
+        if (pg.fpending === "verify")
+            fverifyProc.signal(15);
+        pg.fpending = "";
+        pg.foverlay = false;
+        pg.foverlayMode = "";
+        pg.fstatus = "";
+        pg.fresult = "";
+        pg.fterm = "";
+        pg.fprogress = -1;
+        pg.fnaming = false;
+        pg.fnewFinger = "";
+        pg.fnameDraft = "";
+    }
+    function fappendTerm(raw) {
+        var t = (raw || "").trim();
+        if (!t) return;
+        // Strip "Using device ..." lines, keep the rest
+        var lines = t.split("\n");
+        var out = [];
+        for (var i = 0; i < lines.length; i++) {
+            var s = lines[i].trim();
+            if (s && !s.match(/^Using device/i))
+                out.push(s);
+        }
+        if (out.length > 0)
+            pg.fterm += out.join("\n") + "\n";
+    }
+    function fsaveName() {
+        if (pg.fnewFinger !== "" && pg.fnameDraft.trim() !== "") {
+            pg.fnames[pg.fnewFinger] = pg.fnameDraft.trim();
+            fwriteNames();
+        }
+        pg.fnewFinger = "";
+        pg.fnameDraft = "";
+        pg.fnaming = false;
+        pg.freload();
+        pg.fcloseOverlay();
+    }
+    function fskipName() {
+        if (pg.fnewFinger !== "") {
+            var label = pg.fnewFinger.replace(/-/g, " ");
+            pg.fnames[pg.fnewFinger] = label;
+            fwriteNames();
+        }
+        pg.fnewFinger = "";
+        pg.fnameDraft = "";
+        pg.fnaming = false;
+        pg.freload();
+        pg.fcloseOverlay();
     }
 
     function browseStore() {
@@ -277,6 +463,107 @@ Item {
         }
     }
 
+    // ── fingerprint backend (fprintd as this user; no root) ──────────────────
+    Process {
+        id: freadProc
+        command: [ "bash", "-c", "[ -f \"$HOME/.config/qylock/fingerprint\" ] && cat \"$HOME/.config/qylock/fingerprint\" || printf 'on'" ]
+        stdout: StdioCollector { id: freadOut }
+        onExited: () => {
+            var v = freadOut.text.trim().toLowerCase();
+            pg.ffpEnabled = !(v === "off" || v === "0" || v === "false");
+        }
+    }
+    Process {
+        id: flistProc
+        command: ["fprintd-list", pg.fuser]
+        stdout: StdioCollector { id: flistOut }
+        onExited: (code) => {
+            if (code !== 0 && flistOut.text.trim() === "") {
+                pg.fdaemon = false; pg.fready = false; pg.ffingers = []; pg.floading = false;
+                pg.ferr = "The fingerprint service is not running.";
+                return;
+            }
+            pg.ferr = "";
+            pg.fparseList(flistOut.text);
+        }
+    }
+    Process {
+        id: fwriteProc
+        onExited: () => { pg.freload(); }
+    }
+    Process {
+        id: fnamesReadProc
+        command: ["bash", "-c", "[ -f \"$HOME/.config/qylock/fingerprints.json\" ] && cat \"$HOME/.config/qylock/fingerprints.json\" || printf '{}'" ]
+        stdout: StdioCollector { id: fnamesReadOut }
+        onExited: () => { pg.fparseNames(fnamesReadOut.text); }
+    }
+    Process {
+        id: fnamesWriteProc
+        stdinEnabled: true
+        onStarted: {
+            if (pg.fnames !== undefined) {
+                write(JSON.stringify(pg.fnames));
+            }
+        }
+        onExited: () => { pg.freload(); }
+    }
+    Process {
+        id: fenrollProc
+        stdout: StdioCollector { id: fenOut; waitForEnd: false }
+        stderr: StdioCollector { id: fenErr; waitForEnd: false; onDataChanged: pg.fappendTerm(this.text) }
+        onExited: (code) => {
+            pg.fpending = "";
+            var t = (fenErr.text || "") + (fenOut.text || "");
+            pg.fappendTerm("\n--- " + (code === 0 ? "DONE" : "EXIT " + code) + " ---\n");
+            if (/enroll-completed/i.test(t)) {
+                var m = t.match(/Enrolling\s+([a-z0-9-]+-finger)/i);
+                if (m) {
+                    pg.fnewFinger = m[1];
+                    pg.fnameDraft = m[1].replace(/-/g, " ");
+                    pg.fnaming = true;
+                    pg.fresult = "Enrollment complete. Name this fingerprint.";
+                    return;
+                }
+                pg.fresult = "Fingerprint enrolled.";
+            } else if (/enroll-data-full/i.test(t)) {
+                pg.fresult = "Storage full.";
+            } else if (code !== 0) {
+                pg.fresult = code === 124 ? "Timed out." : "Enrollment stopped.";
+            }
+            pg.freload();
+        }
+    }
+    Process {
+        id: fverifyProc
+        stdout: StdioCollector { id: fverOut; waitForEnd: false }
+        stderr: StdioCollector { id: fverErr; waitForEnd: false; onDataChanged: pg.fappendTerm(this.text) }
+        onExited: (code) => {
+            pg.fpending = "";
+            var t = (fverErr.text || "") + (fverOut.text || "");
+            pg.fappendTerm("\n--- " + (code === 0 ? "MATCH" : "NO MATCH") + " ---\n");
+            if (code === 0 || /verified/i.test(t)) {
+                pg.fresult = "Fingerprint verified.";
+            } else {
+                pg.fresult = "No match.";
+            }
+        }
+    }
+    Process {
+        id: fdelProc
+        stderr: StdioCollector { id: fdelErr }
+        onExited: (code) => {
+            pg.fpending = "";
+            if (code !== 0)
+                pg.ferr = fdelErr.text.trim() || ("Couldn't remove the fingerprint (exit " + code + ").");
+            else if (pg.fpending === "del") {
+                // If we deleted a specific finger, remove it from names
+                // fdelete is called with the finger name, so we need to track it
+                // For simplicity, just reload names (fwriteNames cleans up missing)
+            }
+            pg.freload();
+        }
+    }
+
     // ── head: eyebrow, Fraunces title + refresh, blurb, error line ──────────
     Column {
         id: head
@@ -393,14 +680,13 @@ Item {
         color: Tokens.inkMuted; font.family: Tokens.ui; font.pixelSize: Tokens.fBody
     }
 
-    // ── "At sign-in": the keyring unlock mode, a compact hairline card ───────
+    // ── Sign-in & Fingerprint: combined collapsible settings card ──────────────
     Rectangle {
-        id: signin
+        id: sett
+        property bool open: false
         anchors { left: parent.left; right: parent.right; top: head.bottom }
-        anchors.leftMargin: Tokens.s6
-        anchors.rightMargin: Tokens.s6
-        anchors.topMargin: Tokens.s4
-        implicitHeight: signinCol.implicitHeight + Tokens.s4 * 2
+        anchors.leftMargin: Tokens.s6; anchors.rightMargin: Tokens.s6; anchors.topMargin: Tokens.s4
+        implicitHeight: settCol.implicitHeight + Tokens.s4 * 2
         height: implicitHeight
         radius: Tokens.radius
         color: "transparent"
@@ -408,122 +694,128 @@ Item {
         border.color: Tokens.line
 
         Column {
-            id: signinCol
+            id: settCol
             anchors { left: parent.left; right: parent.right; top: parent.top }
-            anchors.leftMargin: Tokens.s4
-            anchors.rightMargin: Tokens.s4
-            anchors.topMargin: Tokens.s4
+            anchors.leftMargin: Tokens.s4; anchors.rightMargin: Tokens.s4; anchors.topMargin: Tokens.s4
             spacing: Tokens.s2
 
+            // header with collapse chevron
             Row {
                 width: parent.width
                 spacing: Tokens.s2
                 Text {
                     anchors.verticalCenter: parent.verticalCenter
-                    text: I18n.tr("At sign-in")
+                    text: I18n.tr("Sign-in & Fingerprint")
                     color: Tokens.ink; font.family: Tokens.ui
                     font.pixelSize: Tokens.fRow; font.weight: Font.DemiBold
                 }
                 Text {
                     anchors.verticalCenter: parent.verticalCenter
                     width: parent.width - x
-                    text: I18n.tr("How the keyring unlocks your saved passwords and secrets.")
+                    text: pg.settOpen ? "" : (pg.kStatusLine + "  \u00b7  " + pg.fStatusLine)
                     color: Tokens.inkMuted; font.family: Tokens.ui
                     font.pixelSize: Tokens.fSmall; elide: Text.ElideRight
                 }
-            }
-
-            // three-mode chip row.
-            Row {
-                topPadding: Tokens.s1
-                spacing: Tokens.s2
-                Chip { label: I18n.tr("Unlock at sign-in"); mode: "unlock-on-login" }
-                Chip { label: I18n.tr("Never ask"); mode: "never-ask" }
-                Chip { label: I18n.tr("Ask each time"); mode: "ask" }
-            }
-
-            // live status line + caveats from `ryoku keyring status`.
-            Text {
-                width: parent.width
-                topPadding: Tokens.s1
-                text: pg.kStatusLine
-                color: Tokens.inkDim; font.family: Tokens.ui
-                font.pixelSize: Tokens.fSmall; wrapMode: Text.WordWrap
-            }
-            Text {
-                width: parent.width
-                visible: pg.knotes.length > 0 && pg.kconvertFor === ""
-                text: pg.knotes.join("\n")
-                color: Tokens.inkMuted; font.family: Tokens.ui
-                font.pixelSize: Tokens.fSmall; wrapMode: Text.WordWrap
-                lineHeight: 1.3
-            }
-
-            // blocked path: convert with a password, or start fresh (backs up).
-            Column {
-                width: parent.width
-                visible: pg.kconvertFor !== ""
-                topPadding: Tokens.s2
-                spacing: Tokens.s2
-                Text {
-                    width: parent.width
-                    text: I18n.tr("That keyring is locked with a password. Enter it to switch it to no-password, or start fresh (your old keyring is backed up, never deleted).")
-                    color: Tokens.inkMuted; font.family: Tokens.ui
-                    font.pixelSize: Tokens.fSmall; wrapMode: Text.WordWrap
+                Glyph {
+                    anchors.verticalCenter: parent.verticalCenter
+                    path: pg.pChevron; size: 15; weight: 2; rotation: pg.settOpen ? 90 : -90
+                    tint: Tokens.ink
+                    Behavior on rotation { NumberAnimation { duration: Tokens.snap } }
                 }
-                Row {
+            }
+
+            TapHandler { onTapped: pg.settOpen = !pg.settOpen }
+
+            // collapsible content
+            Column {
+                visible: pg.settOpen
+                spacing: Tokens.s3
+                topPadding: Tokens.s2
+
+                // ── Keyring section ──
+                Column {
                     spacing: Tokens.s2
-                    Rectangle {
-                        anchors.verticalCenter: parent.verticalCenter
-                        width: 240; height: Tokens.ctlH + 4
-                        radius: Tokens.radius; color: "transparent"
-                        border.width: Tokens.border
-                        border.color: kpwField.activeFocus ? Tokens.ink : Tokens.line
-                        Behavior on border.color { ColorAnimation { duration: Tokens.snap } }
-                        TextInput {
-                            id: kpwField
-                            anchors.fill: parent
-                            anchors.leftMargin: Tokens.s3
-                            anchors.rightMargin: Tokens.s3
-                            verticalAlignment: TextInput.AlignVCenter
-                            color: Tokens.ink; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall
-                            echoMode: TextInput.Password
-                            selectByMouse: true
-                            selectionColor: Tokens.ink
-                            selectedTextColor: Tokens.inkOnBone
-                            onAccepted: pg.kconvert(text)
-                            Text {
-                                anchors { left: parent.left; verticalCenter: parent.verticalCenter }
-                                visible: kpwField.text.length === 0
-                                text: I18n.tr("Current keyring password")
-                                color: Tokens.inkFaint; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall
+
+                    Row {
+                        width: parent.width
+                        spacing: Tokens.s2
+                        Text { text: I18n.tr("Keyring"); color: Tokens.ink; font.family: Tokens.ui; font.pixelSize: Tokens.fMicro; font.weight: Font.Medium; font.capitalization: Font.AllUppercase; font.letterSpacing: Tokens.trackMark }
+                    }
+
+                    // three-mode chip row.
+                    Row { topPadding: Tokens.s1; spacing: Tokens.s2
+                        Chip { label: I18n.tr("Unlock at sign-in"); mode: "unlock-on-login" }
+                        Chip { label: I18n.tr("Never ask"); mode: "never-ask" }
+                        Chip { label: I18n.tr("Ask each time"); mode: "ask" }
+                    }
+
+                    Text { width: parent.width; topPadding: Tokens.s1; text: pg.kStatusLine; color: Tokens.inkDim; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall; wrapMode: Text.WordWrap }
+                    Text { width: parent.width; visible: pg.knotes.length > 0 && pg.kconvertFor === ""; text: pg.knotes.join("\n"); color: Tokens.inkMuted; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall; wrapMode: Text.WordWrap; lineHeight: 1.3 }
+
+                    Column {
+                        width: parent.width; visible: pg.kconvertFor !== ""; topPadding: Tokens.s2; spacing: Tokens.s2
+                        Text { width: parent.width; text: I18n.tr("That keyring is locked with a password. Enter it to switch it to no-password, or start fresh (your old keyring is backed up, never deleted)."); color: Tokens.inkMuted; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall; wrapMode: Text.WordWrap }
+                        Row { spacing: Tokens.s2
+                            Rectangle { anchors.verticalCenter: parent.verticalCenter; width: 240; height: Tokens.ctlH + 4; radius: Tokens.radius; color: "transparent"; border.width: Tokens.border; border.color: kpwField.activeFocus ? Tokens.ink : Tokens.line; Behavior on border.color { ColorAnimation { duration: Tokens.snap } }
+                                TextInput { id: kpwField; anchors.fill: parent; anchors.leftMargin: Tokens.s3; anchors.rightMargin: Tokens.s3; verticalAlignment: TextInput.AlignVCenter; color: Tokens.ink; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall; echoMode: TextInput.Password; selectByMouse: true; selectionColor: Tokens.ink; selectedTextColor: Tokens.inkOnBone; onAccepted: pg.kconvert(text)
+                                    Text { anchors { left: parent.left; verticalCenter: parent.verticalCenter } visible: kpwField.text.length === 0; text: I18n.tr("Current keyring password"); color: Tokens.inkFaint; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall }
+                                }
+                            }
+                            Btn { anchors.verticalCenter: parent.verticalCenter; text: I18n.tr("CONVERT"); compact: true; armed: pg.kpending === "" && kpwField.text.length > 0; onAct: pg.kconvert(kpwField.text) }
+                            Btn { anchors.verticalCenter: parent.verticalCenter; text: pg.kconfirmReset ? I18n.tr("CONFIRM - START FRESH") : I18n.tr("START FRESH (KEEPS A BACKUP)"); compact: true; armed: pg.kpending === ""; onAct: { if (pg.kconfirmReset) pg.kreset(); else pg.kconfirmReset = true; } }
+                        }
+                    }
+                    Text { width: parent.width; visible: pg.kerror !== ""; topPadding: Tokens.s1; text: pg.kerror; color: Tokens.ink; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall; font.weight: Font.Medium; wrapMode: Text.WordWrap }
+                }
+
+                // hairline separator
+                Rectangle { width: parent.width; height: Tokens.border; color: Tokens.line; visible: pg.settOpen && pg.ffingers.length >= 0 }
+
+                // ── Fingerprint section ──
+                Column {
+                    visible: pg.settOpen && (pg.fdaemon || pg.floading)
+                    spacing: Tokens.s2
+
+                    Row {
+                        width: parent.width
+                        spacing: Tokens.s2
+                        Text { text: I18n.tr("Fingerprint"); color: Tokens.ink; font.family: Tokens.ui; font.pixelSize: Tokens.fMicro; font.weight: Font.Medium; font.capitalization: Font.AllUppercase; font.letterSpacing: Tokens.trackMark }
+                    }
+
+                    // toggle row
+                    Row { width: parent.width; topPadding: Tokens.s1; spacing: Tokens.s2
+                        Text { anchors.verticalCenter: parent.verticalCenter; text: I18n.tr("Unlock with fingerprint"); color: Tokens.ink; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall }
+                        Sw { anchors.verticalCenter: parent.verticalCenter; on: pg.ffpEnabled; onToggled: (v) => pg.ftoggle(v) }
+                        Text { anchors.verticalCenter: parent.verticalCenter; text: I18n.tr(pg.ffpEnabled ? "On \u00b7 the lock screen listens for a touch" : "Off \u00b7 password only"); color: Tokens.inkDim; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall; wrapMode: Text.WordWrap; width: parent.width - 200 }
+                    }
+
+                    // enrolled fingers list
+                    Text { width: parent.width; topPadding: Tokens.s1; text: pg.fStatusLine; color: Tokens.inkDim; font.family: Tokens.mono; font.pixelSize: Tokens.fSmall; wrapMode: Text.WordWrap }
+
+                    Column {
+                        spacing: Tokens.s1
+                        Repeater {
+                            model: pg.ffingers
+                            delegate: Row {
+                                width: parent.width
+                                spacing: Tokens.s2
+                                Text { width: 160; text: pg.ffriendly(modelData); color: Tokens.ink; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall }
+                                Text { width: 100; text: modelData; color: Tokens.inkDim; font.family: Tokens.mono; font.pixelSize: Tokens.fSmall }
+                                Btn { text: I18n.tr("VERIFY"); compact: true; onAct: pg.fstartVerify(modelData); armed: pg.fpending === "" && pg.fdaemon && pg.fready }
+                                Btn { text: "\u2715"; compact: true; onAct: pg.fdelete(modelData); armed: pg.fpending === "" }
                             }
                         }
                     }
-                    Btn {
-                        anchors.verticalCenter: parent.verticalCenter
-                        text: I18n.tr("CONVERT"); compact: true
-                        armed: pg.kpending === "" && kpwField.text.length > 0
-                        onAct: pg.kconvert(kpwField.text)
-                    }
-                    Btn {
-                        anchors.verticalCenter: parent.verticalCenter
-                        text: pg.kconfirmReset ? I18n.tr("CONFIRM - START FRESH") : I18n.tr("START FRESH (KEEPS A BACKUP)")
-                        compact: true
-                        armed: pg.kpending === ""
-                        onAct: { if (pg.kconfirmReset) pg.kreset(); else pg.kconfirmReset = true; }
-                    }
-                }
-            }
 
-            // errors in the page's voice: brightest ink, never red.
-            Text {
-                width: parent.width
-                visible: pg.kerror !== ""
-                topPadding: Tokens.s1
-                text: pg.kerror
-                color: Tokens.ink; font.family: Tokens.ui
-                font.pixelSize: Tokens.fSmall; font.weight: Font.Medium; wrapMode: Text.WordWrap
+                    // actions row
+                    Row { topPadding: Tokens.s2; spacing: Tokens.s2
+                        Btn { text: pg.fpending === "" ? I18n.tr("ENROLL FINGERPRINT") : I18n.tr("ENROLLING\u2026"); armed: pg.fpending === "" && pg.fdaemon && pg.fready; onAct: pg.fstartEnroll() }
+                        Btn { text: I18n.tr("VERIFY ANY"); compact: true; armed: pg.fpending === "" && pg.fdaemon && pg.fready && pg.ffingers.length > 0; onAct: pg.fstartVerify("") }
+                        Btn { text: pg.fpending === "confirm" ? I18n.tr("CONFIRM - REMOVE ALL") : I18n.tr("REMOVE ALL"); compact: true; armed: pg.ffingers.length > 0; onAct: { if (pg.fpending === "confirm") { pg.fdelete(""); pg.fpending = ""; } else { pg.fpending = "confirm"; } } }
+                    }
+
+                    Text { width: parent.width; visible: pg.ferr !== ""; topPadding: Tokens.s1; text: pg.ferr; color: Tokens.ink; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall; font.weight: Font.Medium; wrapMode: Text.WordWrap }
+                }
             }
         }
     }
@@ -533,7 +825,7 @@ Item {
         id: flick
         anchors {
             left: parent.left; right: parent.right
-            top: signin.bottom; bottom: parent.bottom
+            top: sett.bottom; bottom: parent.bottom
             leftMargin: Tokens.s6; rightMargin: Tokens.s6
             topMargin: Tokens.s4; bottomMargin: Tokens.s6
         }
@@ -885,5 +1177,171 @@ Item {
 
         HoverHandler { id: hover; cursorShape: Qt.PointingHandCursor }
         TapHandler { onTapped: if (!tile.active && !tile.busy) tile.applied() }
+    }
+
+    // ── enroll/verify modal: mini terminal ──────────────────────────────────
+    Rectangle {
+        id: fovl
+        anchors.fill: parent
+        visible: pg.foverlay
+        opacity: visible ? 1 : 0
+        Behavior on opacity { NumberAnimation { duration: Tokens.swap; easing.type: Tokens.ease } }
+        color: Qt.rgba(0, 0, 0, 0.6)
+        z: 999
+        MouseArea { anchors.fill: parent; onClicked: (m) => { m.accepted = true; } }
+
+        Item {
+            anchors.centerIn: parent
+            width: Math.min(parent.width - Tokens.s6 * 2, 520)
+            height: 340
+
+            Rectangle {
+                id: plate
+                anchors.fill: parent
+                radius: Tokens.radius
+                color: "#1a1a1a"
+                border.width: 1
+                border.color: "#333"
+                clip: true
+
+                Column {
+                    anchors.fill: parent
+                    anchors.margins: 0
+                    spacing: 0
+
+                    // title bar
+                    Rectangle {
+                        width: parent.width
+                        height: 32
+                        color: "#222"
+                        Row {
+                            anchors { left: parent.left; verticalCenter: parent.verticalCenter; leftMargin: Tokens.s3 }
+                            spacing: Tokens.s2
+                            Rectangle { width: 6; height: 6; radius: 3; color: pg.fpending !== "" ? "#4ade80" : "#666" }
+                            Text {
+                                text: pg.foverlayMode === "enroll" ? "fprintd-enroll" : "fprintd-verify"
+                                color: "#888"; font.family: Tokens.mono
+                                font.pixelSize: 10; anchors.verticalCenter: parent.verticalCenter
+                            }
+                        }
+                        // close button
+                        Text {
+                            anchors { right: parent.right; verticalCenter: parent.verticalCenter; rightMargin: Tokens.s3 }
+                            text: "x"; color: closeMa.containsMouse ? "#fff" : "#666"
+                            font.family: Tokens.mono; font.pixelSize: 12; font.bold: true
+                            MouseArea { id: closeMa; anchors.fill: parent; hoverEnabled: true; onClicked: pg.fcloseOverlay() }
+                        }
+                    }
+
+                    // terminal output
+                    Flickable {
+                        id: termScroll
+                        width: parent.width
+                        height: parent.height - 32 - (namingCol.visible ? namingCol.height : 0) - 40
+                        clip: true
+                        contentHeight: termText.implicitHeight + Tokens.s3 * 2
+                        contentY: Math.max(0, contentHeight - height)
+                        flickableDirection: Flickable.VerticalFlick
+                        interactive: contentHeight > height
+                        boundsBehavior: Flickable.StopAtBounds
+
+                        Text {
+                            id: termText
+                            width: parent.width
+                            anchors { left: parent.left; right: parent.right; top: parent.top; margins: Tokens.s3 }
+                            text: pg.fterm !== "" ? pg.fterm : "Waiting for sensor\u2026\n"
+                            color: "#ccc"; font.family: Tokens.mono
+                            font.pixelSize: 11; wrapMode: Text.WordWrap
+                            textFormat: Text.PlainText
+                        }
+
+                        // auto-scroll to bottom on new content
+                        Connections {
+                            target: pg
+                            function onFtermChanged() {
+                                termScroll.contentY = Math.max(0, termScroll.contentHeight - termScroll.height)
+                            }
+                        }
+
+                        // scrollbar track
+                        Rectangle {
+                            anchors.right: parent.right; anchors.rightMargin: 2
+                            width: 4; height: parent.height; radius: 2; color: "#333"
+                            visible: termScroll.contentHeight > termScroll.height
+                            Rectangle {
+                                width: parent.width
+                                height: Math.max(20, parent.height * termScroll.height / termScroll.contentHeight)
+                                radius: 2; color: "#555"
+                                y: termScroll.contentY * parent.height / termScroll.contentHeight
+                            }
+                        }
+                    }
+
+                    // naming step after enroll
+                    Column {
+                        id: namingCol
+                        width: parent.width
+                        visible: pg.fnaming
+                        padding: Tokens.s3
+                        spacing: Tokens.s2
+                        Rectangle {
+                            width: parent.width; height: 1; color: "#333"
+                        }
+                        Text { width: parent.width; text: "Name this fingerprint"; color: "#888"; font.family: Tokens.mono; font.pixelSize: 10 }
+                        Rectangle {
+                            width: parent.width; height: 28; radius: 4; color: "#222"; border.width: 1; border.color: "#444"
+                            TextInput {
+                                anchors.fill: parent; anchors.leftMargin: Tokens.s3; anchors.rightMargin: Tokens.s3; verticalAlignment: TextInput.AlignVCenter
+                                color: "#ddd"; font.family: Tokens.mono; font.pixelSize: 11
+                                text: pg.fnameDraft
+                                onTextChanged: pg.fnameDraft = text
+                                onAccepted: pg.fsaveName()
+                                focus: true
+                            }
+                        }
+                        Row { spacing: Tokens.s2
+                            Btn { text: "SAVE"; onAct: pg.fsaveName() }
+                            Btn { text: "SKIP"; compact: true; onAct: pg.fskipName() }
+                        }
+                    }
+
+                    // bottom bar
+                    Rectangle {
+                        width: parent.width
+                        height: 40
+                        color: "#222"
+                        Row {
+                            anchors { left: parent.left; verticalCenter: parent.verticalCenter; leftMargin: Tokens.s3 }
+                            spacing: Tokens.s2
+                            Text {
+                                visible: pg.fpending !== ""
+                                color: "#4ade80"; font.family: Tokens.mono; font.pixelSize: 10
+                                text: "\u25cf"
+                                SequentialAnimation on opacity {
+                                    loops: Animation.Infinite; running: pg.fpending !== ""
+                                    NumberAnimation { from: 1; to: 0.3; duration: 600 }
+                                    NumberAnimation { from: 0.3; to: 1; duration: 600 }
+                                }
+                            }
+                            Text {
+                                visible: pg.fpending !== ""
+                                color: "#666"; font.family: Tokens.mono; font.pixelSize: 10
+                                text: pg.foverlayMode === "enroll" ? "Touch sensor to enroll" : "Touch sensor to verify"
+                            }
+                            Text {
+                                visible: pg.fpending === "" && pg.fresult !== ""
+                                color: "#888"; font.family: Tokens.mono; font.pixelSize: 10
+                                text: pg.fresult
+                            }
+                        }
+                        Btn {
+                            anchors { right: parent.right; verticalCenter: parent.verticalCenter; rightMargin: Tokens.s3 }
+                            text: pg.fpending !== "" ? "ABORT" : "CLOSE"
+                            onAct: pg.fcloseOverlay()
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/ryoku/hub/quickshell/pages/LockscreenPage.qml
+++ b/ryoku/hub/quickshell/pages/LockscreenPage.qml
@@ -84,11 +84,7 @@ Item {
         return parts.join("  \u00b7  ");
     }
 
-    // ── fingerprint unlock state (fprintd, live) ────────────────────────────
-    // The sensor's lock-screen counterpart of the keyring card above: whether
-    // the grosshack PAM stack offers a touch-to-unlock at the in-session lock,
-    // and enrolment kept inside Settings. Everything reads/writes fprintd as
-    // this user; nothing here touches root PAM files.
+    // ── fingerprint unlock state (fprintd, live; no root writes) ────────────
     property bool ffpEnabled: true            // ~/.config/qylock/fingerprint toggle
     property bool fdaemon: false              // fprintd service reachable
     property bool fready: false               // a device is present
@@ -119,12 +115,7 @@ Item {
     property string fdelConfirmFor: ""        // per-finger delete armed
     property string fdelTarget: ""            // finger being deleted right now
 
-    // ── grosshack elsewhere (sudo / sddm) ────────────────────────────────────
-    // The same mechanism the lock uses, offered for the other password
-    // prompts: one "auth sufficient pam_fprintd_grosshack.so" line at the top
-    // of /etc/pam.d/sudo or /etc/pam.d/sddm. Applied through pkexec (the same
-    // root half as `ryoku keyring set`), always backing the file up first,
-    // and removal only ever deletes the injected line.
+    // grosshack line in /etc/pam.d/{sudo,sddm}; pkexec applies/removes it.
     property bool fpamModuleOk: false         // pam_fprintd_grosshack.so present
     property bool fsudoOn: false              // grosshack line in /etc/pam.d/sudo
     property bool fsddmOn: false              // grosshack line in /etc/pam.d/sddm
@@ -178,8 +169,6 @@ Item {
         return pg.fnames[finger] || finger.replace(/-/g, " ");
     }
 
-    // one human sentence per raw fprintd status token; the empty token means
-    // the conversation just started and the sensor is waiting for a touch.
     function fheadline(mode, s) {
         var retry = {
             "retry-scan": I18n.tr("Scan didn't read cleanly \u2014 touch again"),
@@ -300,9 +289,6 @@ Item {
         pg.fready = t.indexOf("Using device") !== -1 || t.indexOf("Device at") !== -1 || t.indexOf("found ") !== -1;
         pg.fdaemon = pg.fready && t.trim() !== "" && t.indexOf("no devices") === -1;
         pg.floading = false;
-        // drop labels for prints that no longer exist, so a delete can never
-        // leave a ghost name behind in fingerprints.json. Only runs once the
-        // names map itself has loaded, and an empty map deletes nothing.
         if (pg.fdaemon && !pg.floading) {
             var stale = false;
             for (var k in pg.fnames)
@@ -332,7 +318,6 @@ Item {
         fnamesWriteProc.running = true;
         // Write happens in onStarted
     }
-    // reset everything the modal shows; called by both start functions.
     function fopenOverlay(mode, cmd, proc) {
         pg.ferr = "";
         pg.fresult = "";
@@ -354,9 +339,6 @@ Item {
         if (pg.fpending !== "" || !pg.fdaemon || !pg.fready)
             return;
         pg.fopenOverlay("enroll", ["fprintd-enroll"], fenrollProc);
-        // total stages come off the D-Bus device object; the daemon is spawned
-        // by the enroll call itself, so the first probe usually misses and the
-        // retry timer keeps asking until it answers or the enroll ends.
         fstagesProc.running = true;
         stagesRetry.tries = 0;
         stagesRetry.restart();
@@ -375,10 +357,7 @@ Item {
         fdelProc.command = ["fprintd-delete", pg.fuser].concat(finger ? ["-f", finger] : []);
         fdelProc.running = true;
     }
-    // live stream pump: feed each StdioCollector's cumulative buffer here with
-    // its own stream key; only fresh bytes are parsed and appended to the log,
-    // so a stage line is counted exactly once no matter how often dataChanged
-    // fires.
+    // pump fresh bytes of one stream; counts each stage exactly once.
     function fpump(stream, full) {
         full = full || "";
         var start = pg.foffsets[stream] || 0;
@@ -444,7 +423,6 @@ Item {
         }
         pg.fcloseOverlay();
     }
-    // last two log lines, one per Text so long lines elide instead of wrapping
     readonly property var ftail: {
         var lines = pg.fterm.trim().split("\n");
         while (lines.length < 2) lines.unshift("");
@@ -643,11 +621,7 @@ Item {
         }
         onExited: () => { pg.freload(); }
     }
-    // both streams pump through fpump with their own stream key: the collectors
-    // expose the whole cumulative buffer on every dataChanged, and the offset
-    // map makes sure each byte is parsed and logged exactly once. "Enroll
-    // result:" lines arrive on stdout, so without this the progress UI sat
-    // frozen until exit.
+    // both streams pump through fpump (stdout carries "Enroll result:").
     Process {
         id: fenrollProc
         stdout: StdioCollector { id: fenOut; waitForEnd: false; onDataChanged: pg.fpump("out", this.text) }
@@ -679,9 +653,6 @@ Item {
             pg.freload();
         }
     }
-    // total stages come off the D-Bus device object. The enroll call spawns
-    // the daemon, so the first probe usually races it; the retry timer keeps
-    // asking until the property answers or the enroll ends.
     Process {
         id: fstagesProc
         command: [
@@ -729,7 +700,6 @@ Item {
             }
         }
     }
-    // a clean verify closes itself; the result was the point.
     Timer { id: verifyClose; interval: 1400; onTriggered: pg.fcloseOverlay() }
     Process {
         id: fdelProc
@@ -752,8 +722,6 @@ Item {
             pg.fpending = "";
         }
     }
-    // destructive confirms fall back on their own, so an armed state can never
-    // outlive its moment and eat a click hours later.
     Timer {
         id: confirmReset
         interval: 3000
@@ -959,13 +927,9 @@ Item {
                     color: Tokens.inkMuted; font.family: Tokens.ui
                     font.pixelSize: Tokens.fSmall; elide: Text.ElideRight
                 }
-                // the header alone toggles; taps on the controls below stay
-                // interactive instead of collapsing the card
                 TapHandler { onTapped: pg.settOpen = !pg.settOpen }
             }
 
-            // collapsible content: controls left, prints right — the wide
-            // margin becomes the finger list instead of dead space.
             Row {
                 visible: pg.settOpen
                 spacing: Tokens.s5
@@ -1114,10 +1078,7 @@ Item {
                         }
                     }
 
-                    // grosshack elsewhere: the same one-line PAM mechanism,
-                    // offered for sudo and the sign-in screen. Root half runs
-                    // through pkexec; every change backs its file up first and
-                    // removal only deletes the injected line.
+                    // grosshack for sudo / sddm; root half runs via pkexec.
                     Column {
                         visible: pg.fpamModuleOk && !pg.fpamLoading
                         width: parent.width
@@ -1698,10 +1659,6 @@ Item {
         TapHandler { onTapped: if (!tile.active && !tile.busy) tile.applied() }
     }
 
-    // ── enroll / verify overlay ─────────────────────────────────────────────
-    // The hub's grammar instead of a terminal window: a paperLift plate on a
-    // bare click-catcher, a ring that fills stage by stage, one sentence of
-    // guidance, and fprintd's raw output demoted to a two-line log strip.
     component FpRing: Item {
         id: ring
         property real frac: 0            // 0..1 once the total is known

--- a/ryoku/hub/quickshell/pages/LockscreenPage.qml
+++ b/ryoku/hub/quickshell/pages/LockscreenPage.qml
@@ -119,6 +119,46 @@ Item {
     property string fdelConfirmFor: ""        // per-finger delete armed
     property string fdelTarget: ""            // finger being deleted right now
 
+    // ── grosshack elsewhere (sudo / sddm) ────────────────────────────────────
+    // The same mechanism the lock uses, offered for the other password
+    // prompts: one "auth sufficient pam_fprintd_grosshack.so" line at the top
+    // of /etc/pam.d/sudo or /etc/pam.d/sddm. Applied through pkexec (the same
+    // root half as `ryoku keyring set`), always backing the file up first,
+    // and removal only ever deletes the injected line.
+    property bool fpamModuleOk: false         // pam_fprintd_grosshack.so present
+    property bool fsudoOn: false              // grosshack line in /etc/pam.d/sudo
+    property bool fsddmOn: false              // grosshack line in /etc/pam.d/sddm
+    property bool fpamLoading: true
+    property bool fsudoPending: false         // an apply/remove is in flight
+    property bool fsddmPending: false
+    readonly property string fpamLine: "auth        sufficient    pam_fprintd_grosshack.so"
+
+    function fpamReload() {
+        pg.fpamLoading = true;
+        pamStatusProc.running = true;
+    }
+    function fpamToggle(target, on) {         // target: "sudo" | "sddm"
+        if (pg.fpending !== "" || pg.fsudoPending || pg.fsddmPending)
+            return;
+        pg.ferr = "";
+        var f = "/etc/pam.d/" + target;
+        var script;
+        if (on) {
+            script = "f=" + f + "; "
+                + "cp \"$f\" \"$f.ryoku-fp-bak\" 2>/dev/null; "
+                + "grep -q pam_fprintd_grosshack \"$f\" && exit 0; "
+                + "sed -i \"1i " + pg.fpamLine + "\" \"$f\"";
+        } else {
+            script = "f=" + f + "; "
+                + "cp \"$f\" \"$f.ryoku-fp-bak\" 2>/dev/null; "
+                + "sed -i '/pam_fprintd_grosshack/d' \"$f\"";
+        }
+        if (target === "sudo") pg.fsudoPending = true; else pg.fsddmPending = true;
+        pamApplyProc.target = target;
+        pamApplyProc.command = ["pkexec", "bash", "-c", script];
+        pamApplyProc.running = true;
+    }
+
     readonly property string fStatusLine: {
         if (pg.floading)
             return "Checking\u2026";
@@ -183,7 +223,7 @@ Item {
 
     property bool settOpen: false
 
-    Component.onCompleted: { pg.reload(); pg.kreload(); pg.freload(); }
+    Component.onCompleted: { pg.reload(); pg.kreload(); pg.freload(); pg.fpamReload(); }
 
     function kreload() {
         kstatusProc.running = true;
@@ -237,6 +277,7 @@ Item {
         freadProc.running = true;
         flistProc.running = true;
         fnamesReadProc.running = true;
+        pg.fpamReload();
     }
     function fparseList(text) {
         var t = text || "";
@@ -719,6 +760,44 @@ Item {
         onTriggered: { pg.frmConfirm = false; pg.fdelConfirmFor = ""; }
     }
 
+    // ── grosshack elsewhere: status of /etc/pam.d/{sudo,sddm} ────────────────
+    Process {
+        id: pamStatusProc
+        command: ["bash", "-c",
+            "printf 'module='; [ -f /usr/lib/security/pam_fprintd_grosshack.so ] && echo 1 || echo 0; "
+            + "for f in sudo sddm; do printf '%s=' \"$f\"; "
+            + "grep -qs pam_fprintd_grosshack \"/etc/pam.d/$f\" && echo 1 || echo 0; done"]
+        stdout: StdioCollector { id: pamStatusOut }
+        onExited: () => {
+            var o = {};
+            (pamStatusOut.text || "").split("\n").forEach(function (line) {
+                var kv = line.split("=");
+                if (kv.length === 2) o[kv[0]] = kv[1].trim();
+            });
+            pg.fpamModuleOk = o["module"] === "1";
+            pg.fsudoOn = o["sudo"] === "1";
+            pg.fsddmOn = o["sddm"] === "1";
+            pg.fpamLoading = false;
+        }
+    }
+    Process {
+        id: pamApplyProc
+        property string target: ""
+        stderr: StdioCollector { id: pamApplyErr }
+        onExited: (code) => {
+            if (pamApplyProc.target === "sudo") pg.fsudoPending = false; else pg.fsddmPending = false;
+            if (code !== 0) {
+                var t = pamApplyProc.target === "sudo" ? I18n.tr("sudo") : I18n.tr("the sign-in screen");
+                pg.ferr = (pamApplyErr.text.trim() !== "")
+                    ? I18n.tr("Couldn't update") + " " + t + ": " + pamApplyErr.text.trim()
+                    : I18n.tr("Couldn't update") + " " + t + " (" + I18n.tr("cancelled?") + ")";
+            } else {
+                pg.ferr = "";
+            }
+            pg.fpamReload();
+        }
+    }
+
     // ── head: eyebrow, Fraunces title + refresh, blurb, error line ──────────
     Column {
         id: head
@@ -854,7 +933,8 @@ Item {
             anchors.leftMargin: Tokens.s4; anchors.rightMargin: Tokens.s4; anchors.topMargin: Tokens.s4
             spacing: Tokens.s2
 
-            // header with collapse chevron
+            // header with collapse chevron riding beside the title (not the
+            // far edge, where it read as decoration instead of the control)
             Row {
                 width: parent.width
                 spacing: Tokens.s2
@@ -864,31 +944,41 @@ Item {
                     color: Tokens.ink; font.family: Tokens.ui
                     font.pixelSize: Tokens.fRow; font.weight: Font.DemiBold
                 }
-                Text {
-                    anchors.verticalCenter: parent.verticalCenter
-                    width: parent.width - x
-                    text: pg.settOpen ? "" : (pg.kStatusLine + "  \u00b7  " + pg.fStatusLine)
-                    color: Tokens.inkMuted; font.family: Tokens.ui
-                    font.pixelSize: Tokens.fSmall; elide: Text.ElideRight
-                }
                 Glyph {
                     anchors.verticalCenter: parent.verticalCenter
                     path: pg.pChevron; size: 15; weight: 2; rotation: pg.settOpen ? 90 : -90
                     tint: Tokens.ink
                     Behavior on rotation { NumberAnimation { duration: Tokens.snap } }
                 }
+                Item { width: Tokens.s1; height: 1 }
+                Text {
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: Math.max(0, parent.width - x)
+                    text: pg.settOpen ? "" : (pg.kStatusLine + "  \u00b7  " + pg.fStatusLine)
+                    horizontalAlignment: Text.AlignRight
+                    color: Tokens.inkMuted; font.family: Tokens.ui
+                    font.pixelSize: Tokens.fSmall; elide: Text.ElideRight
+                }
+                // the header alone toggles; taps on the controls below stay
+                // interactive instead of collapsing the card
+                TapHandler { onTapped: pg.settOpen = !pg.settOpen }
             }
 
-            TapHandler { onTapped: pg.settOpen = !pg.settOpen }
-
-            // collapsible content
-            Column {
+            // collapsible content: controls left, prints right — the wide
+            // margin becomes the finger list instead of dead space.
+            Row {
                 visible: pg.settOpen
-                spacing: Tokens.s3
-                topPadding: Tokens.s2
+                spacing: Tokens.s5
+
+                // ── left: keyring, sensor, switches ──
+                Column {
+                    id: settingsLeft
+                    width: Math.round((settCol.width - Tokens.s5 - Tokens.border) * 0.56)
+                    spacing: Tokens.s3
 
                 // ── Keyring section ──
                 Column {
+                    width: parent.width
                     spacing: Tokens.s2
 
                     Row {
@@ -926,14 +1016,8 @@ Item {
                 // hairline separator
                 Rectangle { width: parent.width; height: Tokens.border; color: Tokens.line; visible: pg.settOpen && pg.ffingers.length >= 0 }
 
-                // ── Fingerprint section ──
-                // Always rendered while the sheet is open: a missing daemon or
-                // sensor must explain itself here instead of hiding the row,
-                // or "why doesn't the lock offer my finger" has no answer.
-                // Explicit width: a bare Column sizes to its widest child, which
-                // collapsed every right-pinned control into the left third.
+                // ── fingerprint: sensor & switches ──
                 Column {
-                    visible: pg.settOpen
                     width: parent.width
                     spacing: Tokens.s2
 
@@ -1030,6 +1114,107 @@ Item {
                         }
                     }
 
+                    // grosshack elsewhere: the same one-line PAM mechanism,
+                    // offered for sudo and the sign-in screen. Root half runs
+                    // through pkexec; every change backs its file up first and
+                    // removal only deletes the injected line.
+                    Column {
+                        visible: pg.fpamModuleOk && !pg.fpamLoading
+                        width: parent.width
+                        spacing: Tokens.s2
+
+                        Rectangle { width: parent.width; height: Tokens.border; color: Tokens.lineSoft }
+
+                        Item {
+                            width: parent.width
+                            height: Math.max(sudoCol.height, sudoSw.implicitHeight)
+                            Column {
+                                id: sudoCol
+                                anchors { left: parent.left; right: sudoSw.left; rightMargin: Tokens.s4; verticalCenter: parent.verticalCenter }
+                                spacing: 2
+                                Text { text: I18n.tr("Sudo"); color: Tokens.ink; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall }
+                                Text {
+                                    width: parent.width
+                                    text: I18n.tr("Touch instead of typing for admin commands")
+                                    color: Tokens.inkDim; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall
+                                    wrapMode: Text.WordWrap
+                                }
+                            }
+                            Sw {
+                                id: sudoSw
+                                anchors { right: parent.right; verticalCenter: parent.verticalCenter }
+                                opacity: pg.fsudoPending ? 0.4 : 1
+                                Behavior on opacity { NumberAnimation { duration: Tokens.snap } }
+                                on: pg.fsudoOn
+                                onToggled: (v) => pg.fpamToggle("sudo", v)
+                            }
+                        }
+
+                        Item {
+                            width: parent.width
+                            height: Math.max(sddmCol.height, sddmSw.implicitHeight)
+                            Column {
+                                id: sddmCol
+                                anchors { left: parent.left; right: sddmSw.left; rightMargin: Tokens.s4; verticalCenter: parent.verticalCenter }
+                                spacing: 2
+                                Text { text: I18n.tr("Sign-in screen"); color: Tokens.ink; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall }
+                                Text {
+                                    width: parent.width
+                                    text: I18n.tr("Fingerprint at the greeter too (SDDM)")
+                                    color: Tokens.inkDim; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall
+                                    wrapMode: Text.WordWrap
+                                }
+                            }
+                            Sw {
+                                id: sddmSw
+                                anchors { right: parent.right; verticalCenter: parent.verticalCenter }
+                                opacity: pg.fsddmPending ? 0.4 : 1
+                                Behavior on opacity { NumberAnimation { duration: Tokens.snap } }
+                                on: pg.fsddmOn
+                                onToggled: (v) => pg.fpamToggle("sddm", v)
+                            }
+                        }
+
+                        // hairline
+                        Rectangle { width: parent.width; height: Tokens.border; color: Tokens.lineSoft }
+                    }
+                }
+                }
+
+                // vertical rule between the halves
+                Rectangle {
+                    width: Tokens.border
+                    height: Math.max(settingsLeft.height, settingsRight.height)
+                    color: Tokens.lineSoft
+                }
+
+                // ── right: the enrolled prints ──
+                Column {
+                    id: settingsRight
+                    width: settCol.width - settingsLeft.width - Tokens.s5 * 2 - Tokens.border
+                    spacing: Tokens.s2
+
+                    Row {
+                        width: parent.width
+                        spacing: Tokens.s2
+                        Text { text: I18n.tr("Prints"); color: Tokens.ink; font.family: Tokens.ui; font.pixelSize: Tokens.fMicro; font.weight: Font.Medium; font.capitalization: Font.AllUppercase; font.letterSpacing: Tokens.trackMark }
+                        Text {
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: Math.max(0, parent.width - x)
+                            horizontalAlignment: Text.AlignRight
+                            text: pg.fpending === "enroll" ? I18n.tr("ENROLLING\u2026") : (pg.floading ? I18n.tr("Checking\u2026") : "")
+                            color: Tokens.inkFaint; font.family: Tokens.ui
+                            font.pixelSize: Tokens.fTiny; elide: Text.ElideRight
+                        }
+                    }
+                    Text {
+                        width: parent.width
+                        visible: !pg.floading && pg.ffingers.length === 0
+                        text: I18n.tr("No prints yet. Enroll one below and it will show up here.")
+                        color: Tokens.inkMuted; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall
+                        wrapMode: Text.WordWrap
+                    }
+
                     // enrolled fingers: one quiet row each, delete behind an
                     // armed second click so nothing vanishes on a stray tap.
                     Column {
@@ -1103,34 +1288,39 @@ Item {
                     }
 
                     // actions
-                    Row {
+                    Column {
+                        width: parent.width
                         topPadding: Tokens.s1
                         spacing: Tokens.s2
 
                         Btn {
+                            width: parent.width
                             text: pg.fpending === "enroll" ? I18n.tr("ENROLLING\u2026") : I18n.tr("ENROLL FINGERPRINT")
                             primary: true
                             armed: pg.fpending === "" && pg.fdaemon && pg.fready
                             onAct: pg.fstartEnroll()
                         }
-                        Btn {
-                            text: pg.fpending === "verify" ? I18n.tr("VERIFYING\u2026") : I18n.tr("VERIFY")
-                            compact: true
-                            armed: pg.fpending === "" && pg.fdaemon && pg.fready && pg.ffingers.length > 0
-                            onAct: pg.fstartVerify("")
-                        }
-                        Btn {
-                            text: pg.frmConfirm ? I18n.tr("CONFIRM \u00b7 REMOVE ALL") : I18n.tr("REMOVE ALL")
-                            compact: true
-                            armed: pg.ffingers.length > 0 && pg.fpending === ""
-                            onAct: {
-                                if (pg.frmConfirm) {
-                                    confirmReset.stop();
-                                    pg.fdelete("");
-                                } else {
-                                    pg.fdelConfirmFor = "";
-                                    pg.frmConfirm = true;
-                                    confirmReset.restart();
+                        Row {
+                            spacing: Tokens.s2
+                            Btn {
+                                text: pg.fpending === "verify" ? I18n.tr("VERIFYING\u2026") : I18n.tr("VERIFY")
+                                compact: true
+                                armed: pg.fpending === "" && pg.fdaemon && pg.fready && pg.ffingers.length > 0
+                                onAct: pg.fstartVerify("")
+                            }
+                            Btn {
+                                text: pg.frmConfirm ? I18n.tr("CONFIRM \u00b7 REMOVE ALL") : I18n.tr("REMOVE ALL")
+                                compact: true
+                                armed: pg.ffingers.length > 0 && pg.fpending === ""
+                                onAct: {
+                                    if (pg.frmConfirm) {
+                                        confirmReset.stop();
+                                        pg.fdelete("");
+                                    } else {
+                                        pg.fdelConfirmFor = "";
+                                        pg.frmConfirm = true;
+                                        confirmReset.restart();
+                                    }
                                 }
                             }
                         }
@@ -1603,17 +1793,18 @@ Item {
                     font.pixelSize: Tokens.fMicro; font.weight: Font.Medium
                     font.letterSpacing: Tokens.trackMark
                 }
-                Text {
+                // close: a real hit area, not a bare glyph
+                Item {
                     anchors { right: parent.right; verticalCenter: parent.verticalCenter }
-                    text: "\u2715"
-                    color: fpCloseMa.containsMouse ? Tokens.ink : Tokens.inkMuted
-                    font.family: Tokens.ui; font.pixelSize: 13
-                    Behavior on color { ColorAnimation { duration: Tokens.snap } }
-                    MouseArea {
-                        id: fpCloseMa; anchors.fill: parent; hoverEnabled: true
-                        cursorShape: Qt.PointingHandCursor
-                        onClicked: pg.fcloseOverlay()
+                    width: 28; height: 28
+                    Glyph {
+                        anchors.centerIn: parent
+                        path: pg.pX; size: 13; weight: 2
+                        tint: fpCloseMa.hovered ? Tokens.ink : Tokens.inkMuted
+                        Behavior on tint { ColorAnimation { duration: Tokens.snap } }
                     }
+                    HoverHandler { id: fpCloseMa; cursorShape: Qt.PointingHandCursor }
+                    TapHandler { onTapped: pg.fcloseOverlay() }
                 }
             }
 

--- a/ryoku/hub/quickshell/pages/LockscreenPage.qml
+++ b/ryoku/hub/quickshell/pages/LockscreenPage.qml
@@ -46,6 +46,9 @@ Item {
     readonly property string pPlay: "M8 5.4l11 6.6 -11 6.6z"
     readonly property string pChevron: "M6 9.5l6 6 6 -6"
     readonly property string pRefresh: "M21 12a9 9 0 1 1 -2.6 -6.4 M21 3v5h-5"
+    readonly property string pFingerprint: "M2 12a10 10 0 0 1 18-6 M21.8 16c.2-2 .13-5.35 0-6 M5 19.5C5.5 18 6 15 6 12a6 6 0 0 1 .34-2 M9 6.8a6 6 0 0 1 9 5.2v2 M12 10a2 2 0 0 0 -2 2c0 1.02-.1 2.51-.26 4 M14 13.12c0 2.38 0 6.38-1 8.88 M17.29 21.02c.12-.6.43-2.3.5-3.02 M8.65 22c.21-.66.45-1.32.57-2 M2 16h.01"
+    readonly property string pCheck: "M4.5 12.5l5 5L19.5 7"
+    readonly property string pX: "M6 6l12 12 M18 6L6 18"
 
     // ── sign-in keyring state (`ryoku keyring status --json`) ───────────────
     // A separate concern from the skin gallery: how the GNOME keyring unlocks at
@@ -89,7 +92,8 @@ Item {
     property bool ffpEnabled: true            // ~/.config/qylock/fingerprint toggle
     property bool fdaemon: false              // fprintd service reachable
     property bool fready: false               // a device is present
-    property string fdevice: ""
+    property string fdevice: ""               // D-Bus object path
+    property string fdeviceName: ""           // human sensor name, e.g. "Synaptics Sensors"
     property var ffingers: []                 // enrolled names from fprintd
     property var fnames: ({})                 // fingerprint name -> user label map
     property bool floading: true
@@ -97,15 +101,23 @@ Item {
     property string fpending: ""              // "" | "enroll" | "verify" | "del"
     property bool foverlay: false             // the enroll/verify modal
     property string foverlayMode: ""          // "enroll" | "verify"
-    property string fstatus: ""               // live copy from fprintd output
+    property string fstatus: ""               // latest raw fprintd status token
     property string fresult: ""               // last finished action result
-    property string fterm: ""                 // accumulated terminal output
-    property int fprogress: -1                // -1 unknown, else percent
+    property string fterm: ""                 // accumulated terminal output (log strip)
+    property var foffsets: ({})               // consumed length per stream, so live
+                                              // parsing never counts a line twice
+    property int fstagesPassed: 0             // enroll-stage-passed count
+    property int fstagesTotal: 0              // num-enroll-stages; 0 = unknown
     property string fuser: Quickshell.env("USER") || "traveler"
     // naming flow after successful enroll
     property string fnewFinger: ""            // finger name just enrolled (from fprintd)
     property string fnameDraft: ""            // user's draft name for the new finger
     property bool fnaming: false              // showing the name field after enroll
+    // two-step destructive confirms; a stray click can never silently erase a
+    // print, and the armed state falls back on its own after 3s.
+    property bool frmConfirm: false           // REMOVE ALL armed
+    property string fdelConfirmFor: ""        // per-finger delete armed
+    property string fdelTarget: ""            // finger being deleted right now
 
     readonly property string fStatusLine: {
         if (pg.floading)
@@ -114,7 +126,7 @@ Item {
             return "fingerprint service is not running";
         if (!pg.fready)
             return "no fingerprint device found";
-        var parts = [ pg.fdevice || "sensor" ];
+        var parts = [ pg.fdeviceName || pg.fdevice || "sensor" ];
         if (pg.ffingers.length === 0)
             parts.push("no fingers enrolled yet");
         else
@@ -124,6 +136,49 @@ Item {
 
     function ffriendly(finger) {
         return pg.fnames[finger] || finger.replace(/-/g, " ");
+    }
+
+    // one human sentence per raw fprintd status token; the empty token means
+    // the conversation just started and the sensor is waiting for a touch.
+    function fheadline(mode, s) {
+        var retry = {
+            "retry-scan": I18n.tr("Scan didn't read cleanly \u2014 touch again"),
+            "swipe-too-short": I18n.tr("Too short \u2014 hold your finger on the sensor"),
+            "too-fast": I18n.tr("Too fast \u2014 slow down and press again"),
+            "finger-not-centered": I18n.tr("Center your finger on the sensor"),
+            "remove-and-retry": I18n.tr("Lift your finger, then touch again")
+        };
+        var pre = mode === "enroll" ? "enroll" : "verify";
+        if (s.indexOf(pre + "-") === 0)
+            s = s.slice(pre.length + 1);
+        if (mode === "enroll") {
+            if (s === "")
+                return I18n.tr("Touch the sensor");
+            if (s === "stage-passed")
+                return I18n.tr("Stage captured \u2014 lift and touch again");
+            if (s === "completed")
+                return I18n.tr("Enrolled");
+            if (s === "data-full")
+                return I18n.tr("Sensor storage is full");
+            if (s === "duplicate")
+                return I18n.tr("That print is already on the sensor");
+            if (s === "failed")
+                return I18n.tr("The sensor gave up \u2014 try again");
+        } else {
+            if (s === "")
+                return I18n.tr("Touch the sensor");
+            if (s === "match")
+                return I18n.tr("Match");
+            if (s === "no-match")
+                return I18n.tr("No match");
+            if (s === "failed" || s === "unknown-error")
+                return I18n.tr("Verification failed \u2014 try again");
+        }
+        if (s === "disconnected")
+            return I18n.tr("Sensor disconnected");
+        if (retry[s])
+            return retry[s];
+        return I18n.tr("Touch the sensor");
     }
 
     property bool settOpen: false
@@ -188,6 +243,8 @@ Item {
         var dev = "";
         var m = t.match(/Using\s+device\s+(\S+)/i);
         if (m) dev = m[1];
+        var dn = t.match(/on (.+?) \((?:press|swipe)\):/i);
+        pg.fdeviceName = dn ? dn[1] : "";
         var fingers = [];
         var lines = t.split("\n");
         for (var i = 0; i < lines.length; i++) {
@@ -202,6 +259,15 @@ Item {
         pg.fready = t.indexOf("Using device") !== -1 || t.indexOf("Device at") !== -1 || t.indexOf("found ") !== -1;
         pg.fdaemon = pg.fready && t.trim() !== "" && t.indexOf("no devices") === -1;
         pg.floading = false;
+        // drop labels for prints that no longer exist, so a delete can never
+        // leave a ghost name behind in fingerprints.json. Only runs once the
+        // names map itself has loaded, and an empty map deletes nothing.
+        if (pg.fdaemon && !pg.floading) {
+            var stale = false;
+            for (var k in pg.fnames)
+                if (fingers.indexOf(k) === -1) { delete pg.fnames[k]; stale = true; }
+            if (stale) pg.fwriteNames();
+        }
     }
     function ftoggle(v) {
         pg.ffpEnabled = v;
@@ -225,46 +291,73 @@ Item {
         fnamesWriteProc.running = true;
         // Write happens in onStarted
     }
-    function fstartEnroll() {
+    // reset everything the modal shows; called by both start functions.
+    function fopenOverlay(mode, cmd, proc) {
         pg.ferr = "";
         pg.fresult = "";
-        pg.fprogress = -1;
+        pg.fstagesPassed = 0;
+        pg.fstagesTotal = 0;
         pg.fterm = "";
         pg.fstatus = "";
-        pg.fpending = "enroll";
-        pg.foverlayMode = "enroll";
+        pg.foffsets = {};
+        pg.fpending = mode;
+        pg.foverlayMode = mode;
         pg.fnaming = false;
         pg.fnewFinger = "";
         pg.fnameDraft = "";
         pg.foverlay = true;
-        fenrollProc.command = ["fprintd-enroll"];
-        fenrollProc.running = true;
+        proc.command = cmd;
+        proc.running = true;
+    }
+    function fstartEnroll() {
+        if (pg.fpending !== "" || !pg.fdaemon || !pg.fready)
+            return;
+        pg.fopenOverlay("enroll", ["fprintd-enroll"], fenrollProc);
+        // total stages come off the D-Bus device object; the daemon is spawned
+        // by the enroll call itself, so the first probe usually misses and the
+        // retry timer keeps asking until it answers or the enroll ends.
+        fstagesProc.running = true;
+        stagesRetry.tries = 0;
+        stagesRetry.restart();
     }
     function fstartVerify(finger) {
-        pg.ferr = "";
-        pg.fresult = "";
-        pg.fprogress = -1;
-        pg.fterm = "";
-        pg.fstatus = "";
-        pg.fpending = "verify";
-        pg.foverlayMode = "verify";
-        pg.foverlay = true;
-        var cmd = ["fprintd-verify"];
-        if (finger !== "")
-            cmd.push("-f", finger);
-        fverifyProc.command = cmd;
-        fverifyProc.running = true;
+        if (pg.fpending !== "" || !pg.fdaemon || !pg.fready)
+            return;
+        pg.fopenOverlay("verify", finger === "" ? ["fprintd-verify"] : ["fprintd-verify", "-f", finger], fverifyProc);
     }
     function fdelete(finger) {
+        if (pg.fpending !== "")
+            return;
         pg.ferr = "";
+        pg.fdelTarget = finger;
         pg.fpending = "del";
         fdelProc.command = ["fprintd-delete", pg.fuser].concat(finger ? ["-f", finger] : []);
         fdelProc.running = true;
     }
+    // live stream pump: feed each StdioCollector's cumulative buffer here with
+    // its own stream key; only fresh bytes are parsed and appended to the log,
+    // so a stage line is counted exactly once no matter how often dataChanged
+    // fires.
+    function fpump(stream, full) {
+        full = full || "";
+        var start = pg.foffsets[stream] || 0;
+        if (full.length <= start)
+            return;
+        var chunk = full.substring(start);
+        pg.foffsets[stream] = full.length;
+        pg.fappendTerm(chunk);
+        var m, re = /(?:Enroll result|Verify result):\s*([a-z0-9-]+)/gi;
+        while ((m = re.exec(chunk)) !== null) {
+            pg.fstatus = m[1].toLowerCase();
+            if (m[1] === "enroll-stage-passed")
+                pg.fstagesPassed++;
+        }
+    }
     function fcloseOverlay() {
-        if (pg.fpending === "enroll")
+        verifyClose.stop();
+        if (fenrollProc.running)
             fenrollProc.signal(15);
-        if (pg.fpending === "verify")
+        if (fverifyProc.running)
             fverifyProc.signal(15);
         pg.fpending = "";
         pg.foverlay = false;
@@ -272,10 +365,15 @@ Item {
         pg.fstatus = "";
         pg.fresult = "";
         pg.fterm = "";
-        pg.fprogress = -1;
+        pg.fstagesPassed = 0;
+        pg.fstagesTotal = 0;
+        pg.foffsets = {};
         pg.fnaming = false;
         pg.fnewFinger = "";
         pg.fnameDraft = "";
+        // every way out of the modal lands here, so this is the one place
+        // that refreshes the finger list.
+        pg.freload();
     }
     function fappendTerm(raw) {
         var t = (raw || "").trim();
@@ -294,25 +392,22 @@ Item {
     function fsaveName() {
         if (pg.fnewFinger !== "" && pg.fnameDraft.trim() !== "") {
             pg.fnames[pg.fnewFinger] = pg.fnameDraft.trim();
-            fwriteNames();
+            pg.fwriteNames();
         }
-        pg.fnewFinger = "";
-        pg.fnameDraft = "";
-        pg.fnaming = false;
-        pg.freload();
         pg.fcloseOverlay();
     }
     function fskipName() {
         if (pg.fnewFinger !== "") {
-            var label = pg.fnewFinger.replace(/-/g, " ");
-            pg.fnames[pg.fnewFinger] = label;
-            fwriteNames();
+            pg.fnames[pg.fnewFinger] = pg.fnewFinger.replace(/-/g, " ");
+            pg.fwriteNames();
         }
-        pg.fnewFinger = "";
-        pg.fnameDraft = "";
-        pg.fnaming = false;
-        pg.freload();
         pg.fcloseOverlay();
+    }
+    // last two log lines, one per Text so long lines elide instead of wrapping
+    readonly property var ftail: {
+        var lines = pg.fterm.trim().split("\n");
+        while (lines.length < 2) lines.unshift("");
+        return lines.slice(-2);
     }
 
     function browseStore() {
@@ -507,61 +602,121 @@ Item {
         }
         onExited: () => { pg.freload(); }
     }
+    // both streams pump through fpump with their own stream key: the collectors
+    // expose the whole cumulative buffer on every dataChanged, and the offset
+    // map makes sure each byte is parsed and logged exactly once. "Enroll
+    // result:" lines arrive on stdout, so without this the progress UI sat
+    // frozen until exit.
     Process {
         id: fenrollProc
-        stdout: StdioCollector { id: fenOut; waitForEnd: false }
-        stderr: StdioCollector { id: fenErr; waitForEnd: false; onDataChanged: pg.fappendTerm(this.text) }
+        stdout: StdioCollector { id: fenOut; waitForEnd: false; onDataChanged: pg.fpump("out", this.text) }
+        stderr: StdioCollector { id: fenErr; waitForEnd: false; onDataChanged: pg.fpump("err", this.text) }
         onExited: (code) => {
-            pg.fpending = "";
-            var t = (fenErr.text || "") + (fenOut.text || "");
+            stagesRetry.stop();
             pg.fappendTerm("\n--- " + (code === 0 ? "DONE" : "EXIT " + code) + " ---\n");
+            var t = (fenOut.text || "") + "\n" + (fenErr.text || "");
+            pg.fpending = "";
             if (/enroll-completed/i.test(t)) {
-                var m = t.match(/Enrolling\s+([a-z0-9-]+-finger)/i);
-                if (m) {
-                    pg.fnewFinger = m[1];
-                    pg.fnameDraft = m[1].replace(/-/g, " ");
+                // fprintd prints the finger key either hyphenated or spaced;
+                // normalise back to the D-Bus form fprintd-list reports.
+                var m = t.match(/Enrolling\s+\"?([a-z0-9\- ]*finger)\"?\.?/i);
+                if (m && /finger/i.test(m[1])) {
+                    pg.fnewFinger = m[1].trim().replace(/\s+/g, "-").toLowerCase();
+                    pg.fnameDraft = pg.fnewFinger.replace(/-/g, " ");
                     pg.fnaming = true;
-                    pg.fresult = "Enrollment complete. Name this fingerprint.";
+                    pg.fresult = I18n.tr("Enrollment complete. Name this fingerprint.");
                     return;
                 }
-                pg.fresult = "Fingerprint enrolled.";
+                pg.fresult = I18n.tr("Fingerprint enrolled.");
             } else if (/enroll-data-full/i.test(t)) {
-                pg.fresult = "Storage full.";
+                pg.fresult = I18n.tr("Sensor storage is full.");
+            } else if (/enroll-duplicate|enroll-failed|enroll-disconnected|enroll-unknown-error/i.test(t)) {
+                pg.fresult = I18n.tr("Enrollment did not finish \u2014 try again.");
             } else if (code !== 0) {
-                pg.fresult = code === 124 ? "Timed out." : "Enrollment stopped.";
+                pg.fresult = I18n.tr("Enrollment stopped.");
             }
             pg.freload();
+        }
+    }
+    // total stages come off the D-Bus device object. The enroll call spawns
+    // the daemon, so the first probe usually races it; the retry timer keeps
+    // asking until the property answers or the enroll ends.
+    Process {
+        id: fstagesProc
+        command: [
+            "busctl", "call", "net.reactivated.Fprint",
+            "/net/reactivated/Fprint/Device/0",
+            "org.freedesktop.DBus.Properties", "Get",
+            "ss", "net.reactivated.Fprint.Device", "num-enroll-stages"
+        ]
+        stdout: StdioCollector { id: fstagesOut }
+        onExited: (code) => {
+            var m = (fstagesOut.text || "").match(/i\s+(\d+)/);
+            if (code === 0 && m)
+                pg.fstagesTotal = parseInt(m[1]);
+        }
+    }
+    Timer {
+        id: stagesRetry
+        interval: 1500
+        property int tries: 0
+        onTriggered: {
+            if (pg.fpending !== "enroll" || pg.fstagesTotal > 0 || tries >= 3)
+                return;
+            tries++;
+            fstagesProc.running = true;
+            restart();
         }
     }
     Process {
         id: fverifyProc
-        stdout: StdioCollector { id: fverOut; waitForEnd: false }
-        stderr: StdioCollector { id: fverErr; waitForEnd: false; onDataChanged: pg.fappendTerm(this.text) }
+        stdout: StdioCollector { id: fverOut; waitForEnd: false; onDataChanged: pg.fpump("out", this.text) }
+        stderr: StdioCollector { id: fverErr; waitForEnd: false; onDataChanged: pg.fpump("err", this.text) }
         onExited: (code) => {
-            pg.fpending = "";
-            var t = (fverErr.text || "") + (fverOut.text || "");
             pg.fappendTerm("\n--- " + (code === 0 ? "MATCH" : "NO MATCH") + " ---\n");
-            if (code === 0 || /verified/i.test(t)) {
-                pg.fresult = "Fingerprint verified.";
+            pg.fpending = "";
+            var t = (fverOut.text || "") + "\n" + (fverErr.text || "");
+            // fprintd-verify can exit 0 while printing no-match on some
+            // versions; trust the status token over the exit code.
+            if (!/verify-no-match/i.test(t) && (code === 0 || /verify-match/i.test(t))) {
+                pg.fstatus = "verify-match";
+                pg.fresult = I18n.tr("Fingerprint verified.");
+                verifyClose.restart();
             } else {
-                pg.fresult = "No match.";
+                pg.fstatus = "verify-no-match";
+                pg.fresult = I18n.tr("No match.");
             }
         }
     }
+    // a clean verify closes itself; the result was the point.
+    Timer { id: verifyClose; interval: 1400; onTriggered: pg.fcloseOverlay() }
     Process {
         id: fdelProc
         stderr: StdioCollector { id: fdelErr }
         onExited: (code) => {
-            pg.fpending = "";
-            if (code !== 0)
-                pg.ferr = fdelErr.text.trim() || ("Couldn't remove the fingerprint (exit " + code + ").");
-            else if (pg.fpending === "del") {
-                // If we deleted a specific finger, remove it from names
-                // fdelete is called with the finger name, so we need to track it
-                // For simplicity, just reload names (fwriteNames cleans up missing)
+            if (code !== 0) {
+                pg.ferr = fdelErr.text.trim() || (I18n.tr("Couldn't remove the fingerprint") + " (exit " + code + ")");
+            } else {
+                // a named delete drops its label too; REMOVE ALL clears the
+                // whole map. fwriteNames is the single reload path here.
+                if (pg.fdelTarget !== "")
+                    delete pg.fnames[pg.fdelTarget];
+                else
+                    pg.fnames = {};
+                pg.fwriteNames();
             }
-            pg.freload();
+            pg.fdelTarget = "";
+            pg.frmConfirm = false;
+            pg.fdelConfirmFor = "";
+            pg.fpending = "";
         }
+    }
+    // destructive confirms fall back on their own, so an armed state can never
+    // outlive its moment and eat a click hours later.
+    Timer {
+        id: confirmReset
+        interval: 3000
+        onTriggered: { pg.frmConfirm = false; pg.fdelConfirmFor = ""; }
     }
 
     // ── head: eyebrow, Fraunces title + refresh, blurb, error line ──────────
@@ -772,49 +927,223 @@ Item {
                 Rectangle { width: parent.width; height: Tokens.border; color: Tokens.line; visible: pg.settOpen && pg.ffingers.length >= 0 }
 
                 // ── Fingerprint section ──
+                // Always rendered while the sheet is open: a missing daemon or
+                // sensor must explain itself here instead of hiding the row,
+                // or "why doesn't the lock offer my finger" has no answer.
+                // Explicit width: a bare Column sizes to its widest child, which
+                // collapsed every right-pinned control into the left third.
                 Column {
-                    visible: pg.settOpen && (pg.fdaemon || pg.floading)
+                    visible: pg.settOpen
+                    width: parent.width
                     spacing: Tokens.s2
 
                     Row {
                         width: parent.width
                         spacing: Tokens.s2
                         Text { text: I18n.tr("Fingerprint"); color: Tokens.ink; font.family: Tokens.ui; font.pixelSize: Tokens.fMicro; font.weight: Font.Medium; font.capitalization: Font.AllUppercase; font.letterSpacing: Tokens.trackMark }
+                        Text {
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: parent.width - x
+                            text: pg.fStatusLine
+                            horizontalAlignment: Text.AlignRight
+                            color: Tokens.inkFaint; font.family: Tokens.ui
+                            font.pixelSize: Tokens.fTiny; elide: Text.ElideRight
+                        }
                     }
 
-                    // toggle row
-                    Row { width: parent.width; topPadding: Tokens.s1; spacing: Tokens.s2
-                        Text { anchors.verticalCenter: parent.verticalCenter; text: I18n.tr("Unlock with fingerprint"); color: Tokens.ink; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall }
-                        Sw { anchors.verticalCenter: parent.verticalCenter; on: pg.ffpEnabled; onToggled: (v) => pg.ftoggle(v) }
-                        Text { anchors.verticalCenter: parent.verticalCenter; text: I18n.tr(pg.ffpEnabled ? "On \u00b7 the lock screen listens for a touch" : "Off \u00b7 password only"); color: Tokens.inkDim; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall; wrapMode: Text.WordWrap; width: parent.width - 200 }
+                    // sensor identity row: who is listening, and is anyone.
+                    Item {
+                        width: parent.width
+                        height: Math.max(sensorGlyph.height, sensorCol.implicitHeight)
+
+                        Glyph {
+                            id: sensorGlyph
+                            anchors { left: parent.left; top: parent.top; topMargin: 2 }
+                            path: pg.pFingerprint; size: 22; weight: 1.5
+                            tint: pg.fready ? Tokens.ink : Tokens.inkFaint
+                        }
+                        Column {
+                            id: sensorCol
+                            anchors { left: sensorGlyph.right; right: sensorRetry.visible ? sensorRetry.left : parent.right; leftMargin: Tokens.s3; rightMargin: Tokens.s3; verticalCenter: parent.verticalCenter }
+                            spacing: 2
+
+                            Text {
+                                width: parent.width
+                                text: !pg.floading ? (pg.fdeviceName || (pg.fready ? I18n.tr("Fingerprint sensor") : I18n.tr("No fingerprint sensor"))) : I18n.tr("Checking\u2026")
+                                color: pg.fready ? Tokens.ink : Tokens.inkMuted
+                                font.family: Tokens.ui; font.pixelSize: Tokens.fSmall; font.weight: Font.DemiBold
+                                elide: Text.ElideRight
+                            }
+                            Text {
+                                width: parent.width
+                                text: {
+                                    if (pg.floading)
+                                        return "";
+                                    if (!pg.fdaemon)
+                                        return I18n.tr("The fingerprint service is not running. Enroll anyway and it will start on demand.");
+                                    if (!pg.fready)
+                                        return I18n.tr("No sensor found. Check the USB connection, then retry.");
+                                    if (pg.ffingers.length === 0)
+                                        return I18n.tr("Ready. Enroll a finger to unlock with a touch.");
+                                    return I18n.tr("Listening at the lock screen") + (pg.ffpEnabled ? "" : " \u00b7 " + I18n.tr("currently switched off"));
+                                }
+                                color: Tokens.inkDim; font.family: Tokens.ui
+                                font.pixelSize: Tokens.fSmall; wrapMode: Text.WordWrap
+                            }
+                        }
+                        Btn {
+                            id: sensorRetry
+                            anchors { right: parent.right; verticalCenter: parent.verticalCenter }
+                            visible: !pg.floading && (!pg.fdaemon || !pg.fready)
+                            text: I18n.tr("RETRY"); compact: true
+                            onAct: pg.freload()
+                        }
                     }
 
-                    // enrolled fingers list
-                    Text { width: parent.width; topPadding: Tokens.s1; text: pg.fStatusLine; color: Tokens.inkDim; font.family: Tokens.mono; font.pixelSize: Tokens.fSmall; wrapMode: Text.WordWrap }
+                    // hairline
+                    Rectangle { width: parent.width; height: Tokens.border; color: Tokens.lineSoft }
 
+                    // toggle: label + consequence on the left, control pinned right.
+                    Item {
+                        width: parent.width
+                        height: Math.max(toggleCol.height, tog.implicitHeight)
+                        enabled: pg.fready
+
+                        Column {
+                            id: toggleCol
+                            anchors { left: parent.left; right: tog.left; rightMargin: Tokens.s4; verticalCenter: parent.verticalCenter }
+                            spacing: 2
+                            Text { text: I18n.tr("Unlock with fingerprint"); color: Tokens.ink; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall }
+                            Text {
+                                width: parent.width
+                                text: pg.ffpEnabled ? I18n.tr("The lock screen listens for a touch before asking your password")
+                                                    : I18n.tr("Password only")
+                                color: Tokens.inkDim; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall
+                                wrapMode: Text.WordWrap
+                            }
+                        }
+                        Sw {
+                            id: tog
+                            anchors { right: parent.right; verticalCenter: parent.verticalCenter }
+                            on: pg.ffpEnabled
+                            onToggled: (v) => pg.ftoggle(v)
+                        }
+                    }
+
+                    // enrolled fingers: one quiet row each, delete behind an
+                    // armed second click so nothing vanishes on a stray tap.
                     Column {
-                        spacing: Tokens.s1
+                        id: fingerList
+                        width: parent.width
+                        visible: pg.ffingers.length > 0
+                        spacing: 0
+
                         Repeater {
                             model: pg.ffingers
-                            delegate: Row {
-                                width: parent.width
-                                spacing: Tokens.s2
-                                Text { width: 160; text: pg.ffriendly(modelData); color: Tokens.ink; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall }
-                                Text { width: 100; text: modelData; color: Tokens.inkDim; font.family: Tokens.mono; font.pixelSize: Tokens.fSmall }
-                                Btn { text: I18n.tr("VERIFY"); compact: true; onAct: pg.fstartVerify(modelData); armed: pg.fpending === "" && pg.fdaemon && pg.fready }
-                                Btn { text: "\u2715"; compact: true; onAct: pg.fdelete(modelData); armed: pg.fpending === "" }
+                            delegate: Rectangle {
+                                id: fingerRow
+                                required property var modelData
+                                required property int index
+                                readonly property bool armDel: pg.fdelConfirmFor === modelData
+                                width: fingerList.width
+                                height: 34
+                                color: delHover.hovered ? Tokens.tint5 : "transparent"
+                                Behavior on color { ColorAnimation { duration: Tokens.snap } }
+
+                                Text {
+                                    id: fingerName
+                                    anchors { left: parent.left; leftMargin: Tokens.s2; verticalCenter: parent.verticalCenter }
+                                    width: Math.min(220, fingerRow.width - 230)
+                                    text: pg.ffriendly(fingerRow.modelData)
+                                    color: Tokens.ink; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall
+                                    elide: Text.ElideRight
+                                }
+                                Text {
+                                    anchors { left: fingerName.right; leftMargin: Tokens.s3; right: fingerActions.left; rightMargin: Tokens.s3; verticalCenter: parent.verticalCenter }
+                                    text: fingerRow.modelData
+                                    color: Tokens.inkFaint; font.family: Tokens.mono; font.pixelSize: Tokens.fTiny
+                                    elide: Text.ElideRight
+                                }
+                                Row {
+                                    id: fingerActions
+                                    anchors { right: parent.right; rightMargin: Tokens.s2; verticalCenter: parent.verticalCenter }
+                                    spacing: Tokens.s2
+                                    Btn {
+                                        anchors.verticalCenter: parent.verticalCenter
+                                        text: I18n.tr("VERIFY"); compact: true
+                                        armed: pg.fpending === "" && pg.fdaemon && pg.fready
+                                        onAct: pg.fstartVerify(fingerRow.modelData)
+                                    }
+                                    Btn {
+                                        anchors.verticalCenter: parent.verticalCenter
+                                        text: fingerRow.armDel ? I18n.tr("SURE?") : "\u2715"
+                                        compact: true
+                                        armed: pg.fpending === "" && pg.ffingers.length > 0
+                                        onAct: {
+                                            if (fingerRow.armDel) {
+                                                confirmReset.stop();
+                                                pg.fdelete(fingerRow.modelData);
+                                            } else {
+                                                pg.frmConfirm = false;
+                                                pg.fdelConfirmFor = fingerRow.modelData;
+                                                confirmReset.restart();
+                                            }
+                                        }
+                                    }
+                                }
+                                HoverHandler { id: delHover; cursorShape: Qt.ArrowCursor }
+                                // hairline between rows, never after the last
+                                Rectangle {
+                                    anchors { left: parent.left; right: parent.right; bottom: parent.bottom }
+                                    height: Tokens.border; color: Tokens.lineSoft
+                                    visible: fingerRow.index < pg.ffingers.length - 1
+                                }
                             }
                         }
                     }
 
-                    // actions row
-                    Row { topPadding: Tokens.s2; spacing: Tokens.s2
-                        Btn { text: pg.fpending === "" ? I18n.tr("ENROLL FINGERPRINT") : I18n.tr("ENROLLING\u2026"); armed: pg.fpending === "" && pg.fdaemon && pg.fready; onAct: pg.fstartEnroll() }
-                        Btn { text: I18n.tr("VERIFY ANY"); compact: true; armed: pg.fpending === "" && pg.fdaemon && pg.fready && pg.ffingers.length > 0; onAct: pg.fstartVerify("") }
-                        Btn { text: pg.fpending === "confirm" ? I18n.tr("CONFIRM - REMOVE ALL") : I18n.tr("REMOVE ALL"); compact: true; armed: pg.ffingers.length > 0; onAct: { if (pg.fpending === "confirm") { pg.fdelete(""); pg.fpending = ""; } else { pg.fpending = "confirm"; } } }
+                    // actions
+                    Row {
+                        topPadding: Tokens.s1
+                        spacing: Tokens.s2
+
+                        Btn {
+                            text: pg.fpending === "enroll" ? I18n.tr("ENROLLING\u2026") : I18n.tr("ENROLL FINGERPRINT")
+                            primary: true
+                            armed: pg.fpending === "" && pg.fdaemon && pg.fready
+                            onAct: pg.fstartEnroll()
+                        }
+                        Btn {
+                            text: pg.fpending === "verify" ? I18n.tr("VERIFYING\u2026") : I18n.tr("VERIFY")
+                            compact: true
+                            armed: pg.fpending === "" && pg.fdaemon && pg.fready && pg.ffingers.length > 0
+                            onAct: pg.fstartVerify("")
+                        }
+                        Btn {
+                            text: pg.frmConfirm ? I18n.tr("CONFIRM \u00b7 REMOVE ALL") : I18n.tr("REMOVE ALL")
+                            compact: true
+                            armed: pg.ffingers.length > 0 && pg.fpending === ""
+                            onAct: {
+                                if (pg.frmConfirm) {
+                                    confirmReset.stop();
+                                    pg.fdelete("");
+                                } else {
+                                    pg.fdelConfirmFor = "";
+                                    pg.frmConfirm = true;
+                                    confirmReset.restart();
+                                }
+                            }
+                        }
                     }
 
-                    Text { width: parent.width; visible: pg.ferr !== ""; topPadding: Tokens.s1; text: pg.ferr; color: Tokens.ink; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall; font.weight: Font.Medium; wrapMode: Text.WordWrap }
+                    Text {
+                        width: parent.width
+                        visible: pg.ferr !== ""
+                        topPadding: Tokens.s1
+                        text: pg.ferr
+                        color: Tokens.ink; font.family: Tokens.ui
+                        font.pixelSize: Tokens.fSmall; font.weight: Font.Medium; wrapMode: Text.WordWrap
+                    }
                 }
             }
         }
@@ -1179,168 +1508,320 @@ Item {
         TapHandler { onTapped: if (!tile.active && !tile.busy) tile.applied() }
     }
 
-    // ── enroll/verify modal: mini terminal ──────────────────────────────────
-    Rectangle {
-        id: fovl
+    // ── enroll / verify overlay ─────────────────────────────────────────────
+    // The hub's grammar instead of a terminal window: a paperLift plate on a
+    // bare click-catcher, a ring that fills stage by stage, one sentence of
+    // guidance, and fprintd's raw output demoted to a two-line log strip.
+    component FpRing: Item {
+        id: ring
+        property real frac: 0            // 0..1 once the total is known
+        property bool spin: false        // indeterminate until num-stages lands
+        implicitWidth: 108
+        implicitHeight: 108
+
+        // track
+        Shape {
+            anchors.fill: parent
+            preferredRendererType: Shape.CurveRenderer
+            antialiasing: true
+            ShapePath {
+                strokeColor: Tokens.lineSoft
+                strokeWidth: 3
+                fillColor: "transparent"
+                capStyle: ShapePath.RoundCap
+                PathAngleArc { centerX: 54; centerY: 54; radiusX: 48; radiusY: 48; startAngle: 90; sweepAngle: 360 }
+            }
+        }
+        // progress; hidden while spinning so the sweep never lies
+        Shape {
+            anchors.fill: parent
+            visible: !ring.spin
+            preferredRendererType: Shape.CurveRenderer
+            antialiasing: true
+            ShapePath {
+                strokeColor: Tokens.ink
+                strokeWidth: 3
+                fillColor: "transparent"
+                capStyle: ShapePath.RoundCap
+                PathAngleArc {
+                    centerX: 54; centerY: 54; radiusX: 48; radiusY: 48; startAngle: 90
+                    sweepAngle: Math.max(2, ring.frac * 358)
+                    Behavior on sweepAngle { NumberAnimation { duration: 380; easing.type: Easing.OutCubic } }
+                }
+            }
+        }
+        RotationAnimator on rotation {
+            from: 0; to: 360; duration: 1100
+            loops: Animation.Infinite; running: ring.spin
+        }
+    }
+
+    // modal view-state helpers, kept here so bindings below stay readable.
+    readonly property bool fbusy: pg.fpending === "enroll" || pg.fpending === "verify"
+    readonly property bool fmatchWin: pg.fstatus === "verify-match"
+    readonly property real fringFrac: pg.fstagesTotal > 0 ? Math.min(1, pg.fstagesPassed / pg.fstagesTotal) : 0
+
+    MouseArea {
         anchors.fill: parent
+        enabled: pg.foverlay
         visible: pg.foverlay
-        opacity: visible ? 1 : 0
-        Behavior on opacity { NumberAnimation { duration: Tokens.swap; easing.type: Tokens.ease } }
-        color: Qt.rgba(0, 0, 0, 0.6)
+        z: 998
+        // an outside click only dismisses when nothing is running: mid-enroll
+        // it would silently throw away every captured stage.
+        onClicked: { if (!pg.fbusy && !pg.fnaming) pg.fcloseOverlay() }
+    }
+
+    Rectangle {
+        id: fplate
+        anchors.centerIn: parent
+        visible: pg.foverlay
         z: 999
-        MouseArea { anchors.fill: parent; onClicked: (m) => { m.accepted = true; } }
+        width: Math.min(parent.width - Tokens.s6 * 2, 420)
+        height: 368
+        radius: Tokens.radius
+        color: Tokens.paperLift
+        border.width: Tokens.border
+        border.color: Tokens.lineStrong
+        focus: true
+        Keys.onEscapePressed: pg.fcloseOverlay()
 
-        Item {
-            anchors.centerIn: parent
-            width: Math.min(parent.width - Tokens.s6 * 2, 520)
-            height: 340
+        Column {
+            id: fbodyCol
+            anchors.fill: parent
+            anchors.margins: Tokens.s5
+            spacing: Tokens.s4
 
-            Rectangle {
-                id: plate
-                anchors.fill: parent
-                radius: Tokens.radius
-                color: "#1a1a1a"
-                border.width: 1
-                border.color: "#333"
-                clip: true
+            // header: eyebrow + close
+            Item {
+                width: parent.width
+                height: 16
+                Text {
+                    anchors { left: parent.left; verticalCenter: parent.verticalCenter }
+                    text: pg.fnaming ? I18n.tr("NAME THIS PRINT")
+                        : (pg.foverlayMode === "enroll" ? I18n.tr("ENROLLMENT") : I18n.tr("VERIFY"))
+                    color: Tokens.inkFaint; font.family: Tokens.ui
+                    font.pixelSize: Tokens.fMicro; font.weight: Font.Medium
+                    font.letterSpacing: Tokens.trackMark
+                }
+                Text {
+                    anchors { right: parent.right; verticalCenter: parent.verticalCenter }
+                    text: "\u2715"
+                    color: fpCloseMa.containsMouse ? Tokens.ink : Tokens.inkMuted
+                    font.family: Tokens.ui; font.pixelSize: 13
+                    Behavior on color { ColorAnimation { duration: Tokens.snap } }
+                    MouseArea {
+                        id: fpCloseMa; anchors.fill: parent; hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: pg.fcloseOverlay()
+                    }
+                }
+            }
 
+            // body: ring + readout + guidance, or the naming step
+            Item {
+                width: parent.width
+                height: fplate.height - Tokens.s5 * 2 - 16 - logCol.height - footRow.height - Tokens.s4 * 3
+
+                // live enroll: ring fills stage by stage
                 Column {
-                    anchors.fill: parent
-                    anchors.margins: 0
-                    spacing: 0
+                    anchors.centerIn: parent
+                    visible: pg.foverlayMode === "enroll" && !pg.fnaming
+                    spacing: Tokens.s3
 
-                    // title bar
-                    Rectangle {
-                        width: parent.width
-                        height: 32
-                        color: "#222"
-                        Row {
-                            anchors { left: parent.left; verticalCenter: parent.verticalCenter; leftMargin: Tokens.s3 }
-                            spacing: Tokens.s2
-                            Rectangle { width: 6; height: 6; radius: 3; color: pg.fpending !== "" ? "#4ade80" : "#666" }
-                            Text {
-                                text: pg.foverlayMode === "enroll" ? "fprintd-enroll" : "fprintd-verify"
-                                color: "#888"; font.family: Tokens.mono
-                                font.pixelSize: 10; anchors.verticalCenter: parent.verticalCenter
-                            }
+                    Item {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        width: 108; height: 108
+                        FpRing {
+                            anchors.fill: parent
+                            visible: pg.fstatus !== "enroll-completed"
+                            frac: pg.fringFrac
+                            spin: pg.fstagesTotal === 0 && pg.fpending === "enroll"
                         }
-                        // close button
+                        Glyph {
+                            anchors.centerIn: parent
+                            visible: pg.fstatus === "enroll-completed"
+                            path: pg.pCheck; size: 44; weight: 2.2; tint: Tokens.ink
+                        }
                         Text {
-                            anchors { right: parent.right; verticalCenter: parent.verticalCenter; rightMargin: Tokens.s3 }
-                            text: "x"; color: closeMa.containsMouse ? "#fff" : "#666"
-                            font.family: Tokens.mono; font.pixelSize: 12; font.bold: true
-                            MouseArea { id: closeMa; anchors.fill: parent; hoverEnabled: true; onClicked: pg.fcloseOverlay() }
+                            anchors.centerIn: parent
+                            visible: pg.fstatus !== "enroll-completed" && pg.fstagesTotal > 0
+                            text: pg.fstagesPassed + "/" + pg.fstagesTotal
+                            color: Tokens.ink; font.family: Tokens.mono; font.pixelSize: Tokens.fValue
                         }
                     }
-
-                    // terminal output
-                    Flickable {
-                        id: termScroll
+                    Text {
+                        width: 300
+                        horizontalAlignment: Text.AlignHCenter
+                        wrapMode: Text.WordWrap
+                        text: pg.fheadline("enroll", pg.fstatus)
+                        color: Tokens.ink; font.family: Tokens.ui
+                        font.pixelSize: Tokens.fRow; font.weight: Font.DemiBold
+                    }
+                    Text {
                         width: parent.width
-                        height: parent.height - 32 - (namingCol.visible ? namingCol.height : 0) - 40
-                        clip: true
-                        contentHeight: termText.implicitHeight + Tokens.s3 * 2
-                        contentY: Math.max(0, contentHeight - height)
-                        flickableDirection: Flickable.VerticalFlick
-                        interactive: contentHeight > height
-                        boundsBehavior: Flickable.StopAtBounds
+                        horizontalAlignment: Text.AlignHCenter
+                        text: pg.fstatus === "" ? I18n.tr("Each pass fills the ring \u2014 keep touching until it closes")
+                                                : (pg.fdeviceName !== "" ? pg.fdeviceName : "")
+                        color: Tokens.inkDim; font.family: Tokens.ui
+                        font.pixelSize: Tokens.fSmall
+                        elide: Text.ElideRight
+                    }
+                }
 
-                        Text {
-                            id: termText
-                            width: parent.width
-                            anchors { left: parent.left; right: parent.right; top: parent.top; margins: Tokens.s3 }
-                            text: pg.fterm !== "" ? pg.fterm : "Waiting for sensor\u2026\n"
-                            color: "#ccc"; font.family: Tokens.mono
-                            font.pixelSize: 11; wrapMode: Text.WordWrap
-                            textFormat: Text.PlainText
+                // verify: spin while scanning, then the verdict
+                Column {
+                    anchors.centerIn: parent
+                    visible: pg.foverlayMode === "verify"
+                    spacing: Tokens.s3
+
+                    Item {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        width: 108; height: 108
+                        FpRing {
+                            anchors.fill: parent
+                            visible: pg.fpending === "verify"
+                            frac: 0
+                            spin: true
                         }
-
-                        // auto-scroll to bottom on new content
-                        Connections {
-                            target: pg
-                            function onFtermChanged() {
-                                termScroll.contentY = Math.max(0, termScroll.contentHeight - termScroll.height)
-                            }
+                        Glyph {
+                            anchors.centerIn: parent
+                            visible: pg.fpending !== "verify" && pg.fmatchWin
+                            path: pg.pCheck; size: 44; weight: 2.2; tint: Tokens.ink
                         }
-
-                        // scrollbar track
-                        Rectangle {
-                            anchors.right: parent.right; anchors.rightMargin: 2
-                            width: 4; height: parent.height; radius: 2; color: "#333"
-                            visible: termScroll.contentHeight > termScroll.height
-                            Rectangle {
-                                width: parent.width
-                                height: Math.max(20, parent.height * termScroll.height / termScroll.contentHeight)
-                                radius: 2; color: "#555"
-                                y: termScroll.contentY * parent.height / termScroll.contentHeight
-                            }
+                        Glyph {
+                            anchors.centerIn: parent
+                            visible: pg.fpending !== "verify" && !pg.fmatchWin
+                            path: pg.pX; size: 40; weight: 2.2; tint: Tokens.ink
                         }
                     }
-
-                    // naming step after enroll
-                    Column {
-                        id: namingCol
-                        width: parent.width
-                        visible: pg.fnaming
-                        padding: Tokens.s3
-                        spacing: Tokens.s2
-                        Rectangle {
-                            width: parent.width; height: 1; color: "#333"
-                        }
-                        Text { width: parent.width; text: "Name this fingerprint"; color: "#888"; font.family: Tokens.mono; font.pixelSize: 10 }
-                        Rectangle {
-                            width: parent.width; height: 28; radius: 4; color: "#222"; border.width: 1; border.color: "#444"
-                            TextInput {
-                                anchors.fill: parent; anchors.leftMargin: Tokens.s3; anchors.rightMargin: Tokens.s3; verticalAlignment: TextInput.AlignVCenter
-                                color: "#ddd"; font.family: Tokens.mono; font.pixelSize: 11
-                                text: pg.fnameDraft
-                                onTextChanged: pg.fnameDraft = text
-                                onAccepted: pg.fsaveName()
-                                focus: true
-                            }
-                        }
-                        Row { spacing: Tokens.s2
-                            Btn { text: "SAVE"; onAct: pg.fsaveName() }
-                            Btn { text: "SKIP"; compact: true; onAct: pg.fskipName() }
-                        }
+                    Text {
+                        width: 300
+                        horizontalAlignment: Text.AlignHCenter
+                        wrapMode: Text.WordWrap
+                        text: pg.fheadline("verify", pg.fstatus)
+                        color: Tokens.ink; font.family: Tokens.ui
+                        font.pixelSize: Tokens.fRow; font.weight: Font.DemiBold
                     }
-
-                    // bottom bar
-                    Rectangle {
+                    Text {
                         width: parent.width
-                        height: 40
-                        color: "#222"
-                        Row {
-                            anchors { left: parent.left; verticalCenter: parent.verticalCenter; leftMargin: Tokens.s3 }
-                            spacing: Tokens.s2
-                            Text {
-                                visible: pg.fpending !== ""
-                                color: "#4ade80"; font.family: Tokens.mono; font.pixelSize: 10
-                                text: "\u25cf"
-                                SequentialAnimation on opacity {
-                                    loops: Animation.Infinite; running: pg.fpending !== ""
-                                    NumberAnimation { from: 1; to: 0.3; duration: 600 }
-                                    NumberAnimation { from: 0.3; to: 1; duration: 600 }
-                                }
-                            }
-                            Text {
-                                visible: pg.fpending !== ""
-                                color: "#666"; font.family: Tokens.mono; font.pixelSize: 10
-                                text: pg.foverlayMode === "enroll" ? "Touch sensor to enroll" : "Touch sensor to verify"
-                            }
-                            Text {
-                                visible: pg.fpending === "" && pg.fresult !== ""
-                                color: "#888"; font.family: Tokens.mono; font.pixelSize: 10
-                                text: pg.fresult
-                            }
-                        }
-                        Btn {
-                            anchors { right: parent.right; verticalCenter: parent.verticalCenter; rightMargin: Tokens.s3 }
-                            text: pg.fpending !== "" ? "ABORT" : "CLOSE"
-                            onAct: pg.fcloseOverlay()
+                        horizontalAlignment: Text.AlignHCenter
+                        visible: pg.fpending === "verify" && pg.ffingers.length > 0
+                        text: I18n.tr("Comparing against") + " " + (pg.ffingers.length === 1 ? I18n.tr("one enrolled finger") : pg.ffingers.length + " " + I18n.tr("enrolled fingers"))
+                        color: Tokens.inkDim; font.family: Tokens.ui
+                        font.pixelSize: Tokens.fSmall
+                    }
+                }
+
+                // naming step: the print exists, give it a label
+                Column {
+                    anchors.centerIn: parent
+                    visible: pg.fnaming
+                    spacing: Tokens.s2
+
+                    Text {
+                        width: parent.width
+                        horizontalAlignment: Text.AlignHCenter
+                        text: I18n.tr("Enrolled. Name it so the list stays readable.")
+                        color: Tokens.inkDim; font.family: Tokens.ui; font.pixelSize: Tokens.fSmall
+                    }
+                    Field {
+                        id: nameField
+                        width: parent.width
+                        text: pg.fnameDraft
+                        placeholder: I18n.tr("e.g. right index")
+                        onEdited: (v) => pg.fnameDraft = v
+                        onAccepted: pg.fsaveName()
+                    }
+                    Connections {
+                        target: pg
+                        function onFnamingChanged() {
+                            if (pg.fnaming)
+                                nameField.grabFocus()
                         }
                     }
                 }
+            }
+
+            // log strip: the raw conversation, demoted but not gone
+            Column {
+                id: logCol
+                width: parent.width
+                spacing: 3
+                Rectangle { width: parent.width; height: Tokens.border; color: Tokens.lineSoft }
+                Text {
+                    width: parent.width
+                    text: pg.ftail[0]
+                    color: Tokens.inkFaint; font.family: Tokens.mono; font.pixelSize: Tokens.fTiny
+                    elide: Text.ElideRight
+                }
+                Text {
+                    width: parent.width
+                    text: pg.ftail[1] || " "
+                    color: Tokens.inkFaint; font.family: Tokens.mono; font.pixelSize: Tokens.fTiny
+                    elide: Text.ElideRight
+                }
+            }
+
+            // footer: state word left, actions right. Every mode of the modal
+            // resolves from this one row: abort a running scan, save/skip a
+            // fresh print, close a finished one.
+            Item {
+                id: footRow
+                width: parent.width
+                height: 32
+                Row {
+                    anchors { left: parent.left; verticalCenter: parent.verticalCenter }
+                    spacing: Tokens.s2
+                    Rectangle {
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: 6; height: 6; radius: 3
+                        color: Tokens.ink
+                        visible: pg.fbusy
+                        SequentialAnimation on opacity {
+                            loops: Animation.Infinite; running: pg.fbusy
+                            NumberAnimation { from: 1; to: 0.25; duration: 600 }
+                            NumberAnimation { from: 0.25; to: 1; duration: 600 }
+                        }
+                    }
+                    Text {
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: Math.min(240, fplate.width - 170)
+                        text: pg.fbusy ? (pg.fpending === "enroll" ? I18n.tr("Enrolling") : I18n.tr("Verifying")) : pg.fresult
+                        color: Tokens.inkDim; font.family: Tokens.mono; font.pixelSize: Tokens.fTiny
+                        elide: Text.ElideRight
+                    }
+                }
+                Row {
+                    anchors { right: parent.right; verticalCenter: parent.verticalCenter }
+                    spacing: Tokens.s2
+                    Btn {
+                        visible: pg.fnaming
+                        text: I18n.tr("SKIP"); compact: true
+                        armed: pg.fnameDraft.trim() === ""
+                        onAct: pg.fskipName()
+                    }
+                    Btn {
+                        visible: pg.fnaming
+                        text: I18n.tr("SAVE"); compact: true
+                        primary: true
+                        armed: pg.fnameDraft.trim() !== ""
+                        onAct: pg.fsaveName()
+                    }
+                    Btn {
+                        visible: !pg.fnaming
+                        text: pg.fbusy ? I18n.tr("ABORT") : I18n.tr("CLOSE")
+                        compact: true
+                        onAct: pg.fcloseOverlay()
+                    }
+                }
+            }
+        }
+
+        Connections {
+            target: pg
+            function onFoverlayChanged() {
+                if (pg.foverlay)
+                    fplate.forceActiveFocus()
             }
         }
     }

--- a/ryoku/lockscreen/fingerprint-unlock/CHANGELOG.md
+++ b/ryoku/lockscreen/fingerprint-unlock/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+## Fingerprint unlock for in-session lock
+
+### Added
+
+- **Fingerprint touch-to-unlock** on the in-session lock (`ryoku-shell lock`)
+  using `pam_fprintd_grosshack.so` -- the same mechanism the SDDM greeter uses
+- **PAM service `ryoku-lock`** shipped in `assets/pam/` -- no root edit of
+  `/etc/pam.d` needed, self-contained inline module stack
+- **Auto-arm** of fingerprint sensor when the lock surface is secured
+- **Sensor hint** in the orbital theme:
+  - "SENSOR ACTIVE / TOUCH OR TYPE" text with pulse animation
+  - Positioned between user name and password field (eye naturally hits it)
+  - Full brightness `mainText` color while scanning (not dim `subColor`)
+- **Reveal flourish** on fingerprint unlock (no windup, no second auth)
+- **Race condition protection**: `_unlocked` guard prevents `boomSequence` from
+  calling `doLogin()` a second time if fingerprint wins mid-windup
+- **Fingerprint section in Ryoku Settings** (Lockscreen page):
+  - Toggle to enable/disable fingerprint unlock
+  - Enroll, verify, and remove fingerprints
+  - Live terminal-style output during enrollment/verification
+  - Finger naming after enrollment (stored in `fingerprints.json`)
+- **Install script** with backup/restore/uninstall support:
+  - `--dry-run` to preview changes
+  - `--uninstall` to restore from backups
+  - Backups stored in `~/.ryoku-fingerprint-backups/`
+- **Comprehensive documentation**:
+  - Architecture docs explaining PAM flow, grosshack mechanism, data flow
+  - Installation guide with prerequisites and troubleshooting
+  - Testing checklist covering all scenarios
+
+### Changed
+
+- **`SddmShim.qml`**: PAM config changed from default (`login`) to `ryoku-lock`;
+  fingerprint state props exposed to theme; readiness probes for fprintd;
+  auto-arm on `armWhenReady`; re-arm timer (700ms) after failed scan
+- **`lock_shell.qml`**: arm fingerprint on `WlSessionLock.secure`; reset on
+  unlock; `armWhenReady` lifecycle tied to lock surface
+- **Orbital theme `Main.qml`**: fingerprint hint moved above password field;
+  scanning color changed to full brightness; pulse animation added; reveal
+  flourish on sensor win; `_unlocked` race condition guard
+- **`LockscreenPage.qml`**: fingerprint card under "Sign-in & Fingerprint"
+  collapsible section; terminal-style enroll/verify overlay capturing stderr;
+  finger naming flow; JSON-based finger name storage
+
+### Files
+
+| File | Status |
+|---|---|
+| `ryoku/lockscreen/qylock/quickshell-lockscreen/shim/SddmShim.qml` | Modified |
+| `ryoku/lockscreen/qylock/quickshell-lockscreen/lock_shell.qml` | Modified |
+| `ryoku/lockscreen/qylock/quickshell-lockscreen/assets/pam/ryoku-lock` | New |
+| `ryoku/lockscreen/qylock/themes/clockwork/orbital/Main.qml` | Modified |
+| `ryoku/hub/quickshell/pages/LockscreenPage.qml` | Modified |

--- a/ryoku/lockscreen/fingerprint-unlock/CHANGELOG.md
+++ b/ryoku/lockscreen/fingerprint-unlock/CHANGELOG.md
@@ -1,55 +1,41 @@
 # Changelog
 
-## Fingerprint unlock for in-session lock
+## v2 — final
+
+### Fixed
+- **Touch-to-unlock never fired on a fresh lock**: readiness probes finished
+  before `WlSessionLock.secure`, so `armWhenReady` landed too late and no PAM
+  conversation ever started. The shim arms on `onArmWhenReadyChanged`.
+- **Fingerprint only worked after a wrong password**: aborted conversations
+  orphaned their forked `fprintd-verify`; the orphan kept the sensor claim so
+  the next scan silently failed. Every arm now clears stale verifiers first.
+- Dead PAM conversations (`onError`) no longer leave the hint claiming the
+  sensor is listening.
+- `pam.start()` failures surface with config/dir/user context instead of
+  failing silently; finger probe retries while fprintd wakes up.
 
 ### Added
-
-- **Fingerprint touch-to-unlock** on the in-session lock (`ryoku-shell lock`)
-  using `pam_fprintd_grosshack.so` -- the same mechanism the SDDM greeter uses
-- **PAM service `ryoku-lock`** shipped in `assets/pam/` -- no root edit of
-  `/etc/pam.d` needed, self-contained inline module stack
-- **Auto-arm** of fingerprint sensor when the lock surface is secured
-- **Sensor hint** in the orbital theme:
-  - "SENSOR ACTIVE / TOUCH OR TYPE" text with pulse animation
-  - Positioned between user name and password field (eye naturally hits it)
-  - Full brightness `mainText` color while scanning (not dim `subColor`)
-- **Reveal flourish** on fingerprint unlock (no windup, no second auth)
-- **Race condition protection**: `_unlocked` guard prevents `boomSequence` from
-  calling `doLogin()` a second time if fingerprint wins mid-windup
-- **Fingerprint section in Ryoku Settings** (Lockscreen page):
-  - Toggle to enable/disable fingerprint unlock
-  - Enroll, verify, and remove fingerprints
-  - Live terminal-style output during enrollment/verification
-  - Finger naming after enrollment (stored in `fingerprints.json`)
-- **Install script** with backup/restore/uninstall support:
-  - `--dry-run` to preview changes
-  - `--uninstall` to restore from backups
-  - Backups stored in `~/.ryoku-fingerprint-backups/`
-- **Comprehensive documentation**:
-  - Architecture docs explaining PAM flow, grosshack mechanism, data flow
-  - Installation guide with prerequisites and troubleshooting
-  - Testing checklist covering all scenarios
+- **Sudo toggle**: grosshack line injected into `/etc/pam.d/sudo` (pkexec,
+  backup-first, removal deletes only that line).
+- **Sign-in screen toggle**: same for `/etc/pam.d/sddm`.
+- Enroll progress: real stage counts (`num-enroll-stages` via D-Bus, passes
+  parsed live from stdout+stderr), retry guidance in plain language.
+- Verify result plate with match/no-match and auto-close on success.
+- Two-step destructive confirms (per-finger delete, REMOVE ALL).
+- `install.sh` committed (referenced but missing from earlier iterations).
 
 ### Changed
+- Settings card runs full width again (symmetric with the gallery) and splits
+  into two columns: controls left, enrolled prints right.
+- Enroll/verify modal switched from a raw terminal window to the hub's paper
+  style; fprintd output demoted to a two-line log strip.
+- Collapse chevron moved beside the title; only the header toggles the sheet.
 
-- **`SddmShim.qml`**: PAM config changed from default (`login`) to `ryoku-lock`;
-  fingerprint state props exposed to theme; readiness probes for fprintd;
-  auto-arm on `armWhenReady`; re-arm timer (700ms) after failed scan
-- **`lock_shell.qml`**: arm fingerprint on `WlSessionLock.secure`; reset on
-  unlock; `armWhenReady` lifecycle tied to lock surface
-- **Orbital theme `Main.qml`**: fingerprint hint moved above password field;
-  scanning color changed to full brightness; pulse animation added; reveal
-  flourish on sensor win; `_unlocked` race condition guard
-- **`LockscreenPage.qml`**: fingerprint card under "Sign-in & Fingerprint"
-  collapsible section; terminal-style enroll/verify overlay capturing stderr;
-  finger naming flow; JSON-based finger name storage
+### Untouched
+- clockwork/orbital theme files.
 
-### Files
+## v1
 
-| File | Status |
-|---|---|
-| `ryoku/lockscreen/qylock/quickshell-lockscreen/shim/SddmShim.qml` | Modified |
-| `ryoku/lockscreen/qylock/quickshell-lockscreen/lock_shell.qml` | Modified |
-| `ryoku/lockscreen/qylock/quickshell-lockscreen/assets/pam/ryoku-lock` | New |
-| `ryoku/lockscreen/qylock/themes/clockwork/orbital/Main.qml` | Modified |
-| `ryoku/hub/quickshell/pages/LockscreenPage.qml` | Modified |
+- Initial fingerprint unlock wiring: `ryoku-lock` PAM service, SddmShim
+  fingerprint state + auto-arm, sensor hint in the orbital theme,
+  Fingerprint section in hub settings.

--- a/ryoku/lockscreen/fingerprint-unlock/README.md
+++ b/ryoku/lockscreen/fingerprint-unlock/README.md
@@ -1,0 +1,114 @@
+# Fingerprint Unlock for Ryoku Lock Screen
+
+Touch-to-unlock on the in-session lock (`ryoku-shell lock` / `Super+L`) using
+the same `pam_fprintd_grosshack.so` mechanism the SDDM greeter already uses.
+Plus a Fingerprint section in Ryoku Settings for enrollment and management.
+
+## TL;DR
+
+SDDM sign-in already unlocks with a fingerprint because `/etc/pam.d/sddm`
+carries the grosshack pair. The in-session lock did **not** -- its PAM
+conversation used the quickshell default service `login`, which has no
+fingerprint line. This change wires the in-session lock onto the **same
+grosshack mechanism** via a self-contained PAM service shipped with the lock.
+
+## What Changed
+
+### Files
+
+| File (repo path) | Destination | What it does |
+|---|---|---|
+| `ryoku/lockscreen/qylock/quickshell-lockscreen/shim/SddmShim.qml` | `~/.local/share/quickshell-lockscreen/shim/` | PAM config, auto-arm, fingerprint state, readiness probes |
+| `ryoku/lockscreen/qylock/quickshell-lockscreen/lock_shell.qml` | `~/.local/share/quickshell-lockscreen/` | Arm on `secure`, reset on unlock |
+| `ryoku/lockscreen/qylock/quickshell-lockscreen/assets/pam/ryoku-lock` | `~/.local/share/quickshell-lockscreen/assets/pam/` | PAM service (grosshack pair) |
+| `ryoku/lockscreen/qylock/themes/clockwork/orbital/Main.qml` | `~/.local/share/qylock/themes/clockwork/orbital/` | Sensor hint + fingerprint reveal |
+| `ryoku/hub/quickshell/pages/LockscreenPage.qml` | `~/.config/quickshell/hub/pages/` | Fingerprint card + enroll/verify modal |
+
+### New Files
+
+- `assets/pam/ryoku-lock` -- PAM service file (does not exist in upstream)
+- All other files are modifications of existing Ryoku files
+
+## How It Works
+
+See [`docs/architecture.md`](docs/architecture.md) for the full technical
+breakdown. In brief:
+
+1. `loginctl lock-session` or `Super+L` triggers `ryoku-shell lock`
+2. `lock.sh` launches `quickshell -p lock_shell.qml`
+3. `WlSessionLock` secures the screen, `onSecureChanged` sets `armWhenReady = true`
+4. `SddmShim` probes `fprintd-list` and reads `~/.config/qylock/fingerprint`
+5. If enabled and fingers enrolled, `armFingerprint()` starts a PAM conversation
+6. `pam_fprintd_grosshack.so` forks fprintd-verify -- sensor is live
+7. Theme shows "SENSOR ACTIVE / TOUCH OR TYPE" with a pulse animation
+8. Touch the sensor: PAM succeeds, `loginctl unlock-session`
+9. Type a password: `pam_unix` succeeds via the same conversation
+
+## Install
+
+See [`docs/installation.md`](docs/installation.md).
+
+### For testers (before merge)
+
+Install from the PR branch on the fork:
+
+```sh
+git clone https://github.com/Kavy-Codes/ryoku-arch.git -b fingerprint-unlock
+cd ryoku-arch
+./ryoku/lockscreen/fingerprint-unlock/install.sh
+systemctl --user restart ryoku-shell
+```
+
+The installer **backs up** all original files to `~/.ryoku-fingerprint-backups/`
+before overwriting them. You can fully revert at any time:
+
+```sh
+./ryoku/lockscreen/fingerprint-unlock/install.sh --uninstall
+systemctl --user restart ryoku-shell
+```
+
+Remove the test clone when done:
+
+```sh
+rm -rf ryoku-arch
+```
+
+### After merge (upstream)
+
+```sh
+cd ryoku-arch
+./ryoku/lockscreen/fingerprint-unlock/install.sh
+systemctl --user restart ryoku-shell
+```
+
+## Testing
+
+See [`docs/testing.md`](docs/testing.md) for the full checklist.
+
+Quick version:
+
+1. Enroll a finger: Settings -> Lockscreen -> Fingerprint -> ENROLL FINGERPRINT
+2. Lock: `loginctl lock-session` or `Super+L`
+3. Touch sensor: hint appears, touch unlocks (reveal plays)
+4. Type password: still works mid-scan
+5. Toggle off: no sensor hint, password only
+6. SDDM: sign-in screen unchanged
+
+## Dependencies
+
+- `fprintd` with at least one enrolled finger (`fprintd-enroll`)
+- `pam_fprintd_grosshack.so` (already present if SDDM fingerprint works)
+- Quickshell with `Quickshell.Services.Pam` module
+- No new packages required
+
+## Notes
+
+- The hint is in-session only; the SDDM greeter's copy of the theme is untouched
+- Auto-arm waits at the `pam_unix` prompt (no response -> no faillock entry)
+- Re-arm after fail is on a 700ms timer
+- `fingerprintUnlock` is a heuristic (scanning && !typed); it only drives the
+  reveal animation, never gates the unlock itself
+- Enrollment/verify captures stderr from fprintd (where the output goes) and
+  displays it in a styled terminal overlay
+- Race condition protection: `_unlocked` guard prevents double PAM auth if
+  fingerprint wins during windup animation

--- a/ryoku/lockscreen/fingerprint-unlock/README.md
+++ b/ryoku/lockscreen/fingerprint-unlock/README.md
@@ -1,114 +1,94 @@
-# Fingerprint Unlock for Ryoku Lock Screen
+# Fingerprint Unlock for Ryoku
 
-Touch-to-unlock on the in-session lock (`ryoku-shell lock` / `Super+L`) using
-the same `pam_fprintd_grosshack.so` mechanism the SDDM greeter already uses.
-Plus a Fingerprint section in Ryoku Settings for enrollment and management.
+Touch-to-unlock with `pam_fprintd_grosshack.so` in three places:
 
-## TL;DR
+1. **Lock screen** (`ryoku-shell lock` / `Super+L`) — sensor scans while the
+   password field waits; first success wins, same conversation
+2. **Sudo** — touch instead of typing for admin commands (toggle in Settings)
+3. **SDDM greeter** — fingerprint at sign-in (toggle in Settings)
 
-SDDM sign-in already unlocks with a fingerprint because `/etc/pam.d/sddm`
-carries the grosshack pair. The in-session lock did **not** -- its PAM
-conversation used the quickshell default service `login`, which has no
-fingerprint line. This change wires the in-session lock onto the **same
-grosshack mechanism** via a self-contained PAM service shipped with the lock.
+Plus a Fingerprint section in Ryoku Settings → Lockscreen for enrollment,
+verification, deletion and all of the above.
+
+## Why the lock screen needed this
+
+SDDM unlocks with a fingerprint because `/etc/pam.d/sddm` carries the
+grosshack line. The in-session lock used Quickshell's default `login`
+service — no fingerprint. This PR ships a self-contained PAM service
+(`assets/pam/ryoku-lock`) loaded via `PamContext.configDirectory`, so no
+root edit of `/etc/pam.d` is needed for the lock itself.
+
+Two bugs made touch-to-unlock dead on arrival in earlier iterations; both
+are fixed here (see [docs/architecture.md](docs/architecture.md)):
+
+- **Arm race**: readiness probes finish before the compositor confirms the
+  lock surface, so arming never fired. The shim now arms on
+  `onArmWhenReadyChanged`.
+- **Stale verifiers**: an aborted conversation orphaned its forked
+  `fprintd-verify`, which kept the sensor claim — every later scan silently
+  failed until a wasted password cycle re-armed it. Each arm now clears
+  strays first.
+
+## Requirements
+
+| Dependency | Why | Check |
+|---|---|---|
+| `fprintd` | enrollment + verification daemon | `pacman -Q fprintd` |
+| `pam_fprintd_grosshack.so` | parallel touch-or-type PAM module | `ls /usr/lib/security/pam_fprintd_grosshack.so` |
+| `quickshell` ≥ 0.3 (with `Quickshell.Services.Pam`) | lock surface + PAM conversation | `pacman -Q quickshell` |
+| `busctl` (systemd) | reads `num-enroll-stages` for enroll progress | preinstalled on Arch |
+| `pkexec` / polkit | root half of the sudo/SDDM toggles | preinstalled on Arch |
+
+A sensor supported by libfprint is required, and at least one finger must be
+enrolled before any of the toggles do anything visible.
 
 ## What Changed
 
-### Files
+| File | Change |
+|---|---|
+| `ryoku/lockscreen/qylock/quickshell-lockscreen/shim/SddmShim.qml` | arm-on-secure fix, stale verifier cleanup, PAM error handling, probe retries |
+| `ryoku/lockscreen/qylock/quickshell-lockscreen/assets/pam/ryoku-lock` | new: PAM service for the lock |
+| `ryoku/hub/quickshell/pages/LockscreenPage.qml` | Fingerprint section: enroll progress ring, verify plate, sudo/SDDM toggles, two-column card |
+| `ryoku/lockscreen/fingerprint-unlock/install.sh` | new: installer/uninstaller |
 
-| File (repo path) | Destination | What it does |
-|---|---|---|
-| `ryoku/lockscreen/qylock/quickshell-lockscreen/shim/SddmShim.qml` | `~/.local/share/quickshell-lockscreen/shim/` | PAM config, auto-arm, fingerprint state, readiness probes |
-| `ryoku/lockscreen/qylock/quickshell-lockscreen/lock_shell.qml` | `~/.local/share/quickshell-lockscreen/` | Arm on `secure`, reset on unlock |
-| `ryoku/lockscreen/qylock/quickshell-lockscreen/assets/pam/ryoku-lock` | `~/.local/share/quickshell-lockscreen/assets/pam/` | PAM service (grosshack pair) |
-| `ryoku/lockscreen/qylock/themes/clockwork/orbital/Main.qml` | `~/.local/share/qylock/themes/clockwork/orbital/` | Sensor hint + fingerprint reveal |
-| `ryoku/hub/quickshell/pages/LockscreenPage.qml` | `~/.config/quickshell/hub/pages/` | Fingerprint card + enroll/verify modal |
+The clockwork/orbital theme is untouched.
 
-### New Files
+## Settings UI
 
-- `assets/pam/ryoku-lock` -- PAM service file (does not exist in upstream)
-- All other files are modifications of existing Ryoku files
+- **Unlock with fingerprint** — master switch for the lock screen
+  (`~/.config/qylock/fingerprint`, read live at each lock)
+- **Sudo** / **Sign-in screen** — inject or remove one grosshack line at the
+  top of `/etc/pam.d/sudo` / `/etc/pam.d/sddm`. Applied via `pkexec`; every
+  change backs the file up to `/etc/pam.d/<svc>.ryoku-fp-bak` and removal
+  deletes only the injected line.
+- **Prints column** — enrolled fingers with per-finger VERIFY and a two-step
+  delete; ENROLL shows real stage progress (`num-enroll-stages` from D-Bus,
+  stage passes parsed from fprintd output)
 
-## How It Works
-
-See [`docs/architecture.md`](docs/architecture.md) for the full technical
-breakdown. In brief:
-
-1. `loginctl lock-session` or `Super+L` triggers `ryoku-shell lock`
-2. `lock.sh` launches `quickshell -p lock_shell.qml`
-3. `WlSessionLock` secures the screen, `onSecureChanged` sets `armWhenReady = true`
-4. `SddmShim` probes `fprintd-list` and reads `~/.config/qylock/fingerprint`
-5. If enabled and fingers enrolled, `armFingerprint()` starts a PAM conversation
-6. `pam_fprintd_grosshack.so` forks fprintd-verify -- sensor is live
-7. Theme shows "SENSOR ACTIVE / TOUCH OR TYPE" with a pulse animation
-8. Touch the sensor: PAM succeeds, `loginctl unlock-session`
-9. Type a password: `pam_unix` succeeds via the same conversation
-
-## Install
-
-See [`docs/installation.md`](docs/installation.md).
-
-### For testers (before merge)
-
-Install from the PR branch on the fork:
+## Install for Testers
 
 ```sh
-git clone https://github.com/Kavy-Codes/ryoku-arch.git -b fingerprint-unlock
+git clone https://github.com/Kavy-Codes/ryoku-arch.git -b fingerprint-unlock-v2
 cd ryoku-arch
 ./ryoku/lockscreen/fingerprint-unlock/install.sh
 systemctl --user restart ryoku-shell
 ```
 
-The installer **backs up** all original files to `~/.ryoku-fingerprint-backups/`
-before overwriting them. You can fully revert at any time:
+The installer backs up originals to `~/.ryoku-fingerprint-backups/`. Revert:
 
 ```sh
 ./ryoku/lockscreen/fingerprint-unlock/install.sh --uninstall
 systemctl --user restart ryoku-shell
 ```
 
-Remove the test clone when done:
+## Test Checklist
 
-```sh
-rm -rf ryoku-arch
-```
+See [docs/testing.md](docs/testing.md). Short version: enroll → lock → touch
+(no button) → unlock; wrong password still works mid-scan; toggles reflect
+and revert cleanly; deleting fingers keeps labels in sync.
 
-### After merge (upstream)
+## Docs
 
-```sh
-cd ryoku-arch
-./ryoku/lockscreen/fingerprint-unlock/install.sh
-systemctl --user restart ryoku-shell
-```
-
-## Testing
-
-See [`docs/testing.md`](docs/testing.md) for the full checklist.
-
-Quick version:
-
-1. Enroll a finger: Settings -> Lockscreen -> Fingerprint -> ENROLL FINGERPRINT
-2. Lock: `loginctl lock-session` or `Super+L`
-3. Touch sensor: hint appears, touch unlocks (reveal plays)
-4. Type password: still works mid-scan
-5. Toggle off: no sensor hint, password only
-6. SDDM: sign-in screen unchanged
-
-## Dependencies
-
-- `fprintd` with at least one enrolled finger (`fprintd-enroll`)
-- `pam_fprintd_grosshack.so` (already present if SDDM fingerprint works)
-- Quickshell with `Quickshell.Services.Pam` module
-- No new packages required
-
-## Notes
-
-- The hint is in-session only; the SDDM greeter's copy of the theme is untouched
-- Auto-arm waits at the `pam_unix` prompt (no response -> no faillock entry)
-- Re-arm after fail is on a 700ms timer
-- `fingerprintUnlock` is a heuristic (scanning && !typed); it only drives the
-  reveal animation, never gates the unlock itself
-- Enrollment/verify captures stderr from fprintd (where the output goes) and
-  displays it in a styled terminal overlay
-- Race condition protection: `_unlocked` guard prevents double PAM auth if
-  fingerprint wins during windup animation
+- [docs/architecture.md](docs/architecture.md) — PAM flow, arm lifecycle, race fixes
+- [docs/installation.md](docs/installation.md) — install / uninstall / troubleshooting
+- [docs/testing.md](docs/testing.md) — full tester checklist

--- a/ryoku/lockscreen/fingerprint-unlock/docs/architecture.md
+++ b/ryoku/lockscreen/fingerprint-unlock/docs/architecture.md
@@ -1,0 +1,217 @@
+# Architecture: Fingerprint Unlock
+
+This document explains how the fingerprint unlock feature works at every layer,
+from the PAM stack up to the theme UI.
+
+## Overview
+
+```
++-------------------+     +-------------------+     +-------------------+
+|   Theme (QML)     |     |  SddmShim (QML)   |     |  PAM Service      |
+|   Main.qml        |<--->|  SddmShim.qml     |<--->|  ryoku-lock       |
+|                   |     |                   |     |                   |
+| - fpHint text     |     | - PamContext      |     | - grosshack pair  |
+| - fpPulse anim    |     | - fpEnabled       |     | - pam_fprintd     |
+| - boomReveal      |     | - fpHasFingers    |     | - pam_unix        |
+| - _unlocked guard |     | - armFingerprint  |     +-------------------+
++-------------------+     | - resetAuth       |
+                          +-------------------+
+```
+
+## PAM Stack (`assets/pam/ryoku-lock`)
+
+```
+auth  sufficient  pam_fprintd_grosshack.so
+auth  sufficient  pam_unix.so try_first_pass nullok
+auth  required    pam_env.so
+auth  required    pam_deny.so
+account required  pam_unix.so
+password required pam_deny.so
+session required  pam_unix.so
+```
+
+### How grosshack works
+
+`pam_fprintd_grosshack.so` is a modified version of `pam_fprintd` that forks
+`fprintd-verify` at the **start** of the PAM conversation. This means:
+
+1. The fingerprint sensor begins scanning immediately
+2. `pam_unix.so` simultaneously waits for a typed password
+3. The **first** successful auth (touch OR type) wins
+4. Both paths race in the same PAM conversation
+
+This is the same mechanism used in `/etc/pam.d/sddm`, so the behavior at the
+lock screen matches the sign-in screen exactly.
+
+### Why inline (not include)
+
+The `ryoku-lock` file lives in the lock's own `assets/pam/` directory and is
+loaded via `PamContext.configDirectory`. An `include system-login` would resolve
+against this confdir (not `/etc/pam.d`) and fail. The inline tail mirrors the
+module list the bundled DMS lock ships for its lock services.
+
+## SddmShim (`shim/SddmShim.qml`)
+
+The shim replaces the default Quickshell SDDM shim to add fingerprint support.
+It exposes the same API as a real SDDM greeter so themes work unchanged.
+
+### Properties exposed to theme
+
+| Property | Type | Source | Purpose |
+|---|---|---|---|
+| `sddm.fingerprintHint` | bool | hardcoded `true` | Gate: show the sensor hint (false under real SDDM) |
+| `sddm.fingerprintReady` | bool | `fpEnabled && fpHasFingers` | Sensor is available |
+| `sddm.fingerprintState` | string | PAM conversation | `idle` / `scanning` / `success` / `fail` |
+| `sddm.fingerprintUnlock` | bool | PAM completion | True if sensor won (not typed) |
+
+### Readiness probes
+
+Two independent probes run on lock start:
+
+1. **fpToggleProc**: reads `~/.config/qylock/fingerprint` (the Settings toggle)
+2. **fpListProc**: runs `fprintd-list` to check for enrolled fingers
+
+Both call `maybeArm()` when done. The arm only fires when ALL conditions are met:
+- Toggle is on (or file missing, default on)
+- At least one finger is enrolled
+- `armWhenReady` is true (lock surface is secured)
+- No PAM conversation is already active
+
+### PAM conversation flow
+
+```
+armFingerprint()
+  -> pam.user = currentUser
+  -> pam.pendingPassword = ""
+  -> pam.start()
+  -> PAM reads ryoku-lock service
+  -> pam_fprintd_grossfork forks fprintd-verify
+  -> sensor begins scanning
+  -> fingerprintState = "scanning"
+
+  [user touches sensor]
+  -> fprintd-verify succeeds
+  -> PAM conversation completes with Success
+  -> onCompleted(PamResult.Success)
+  -> fingerprintUnlock = (scanning && !typed)
+  -> fingerprintState = "success"
+  -> sddm.loginSucceeded()
+  -> loginctl unlock-session
+
+  [OR user types password]
+  -> onResponseRequiredChanged (pam_unix prompt)
+  -> pam.respond(password)
+  -> PAM conversation completes with Success
+  -> same flow as above, but fingerprintUnlock = false
+
+  [OR scan fails]
+  -> PAM conversation completes with failure
+  -> onCompleted(non-Success)
+  -> fingerprintState = "fail"
+  -> sddm.loginFailed()
+  -> rearmTimer.restart() (700ms)
+  -> sensor re-arms for next touch
+```
+
+## Lock Shell (`lock_shell.qml`)
+
+The entry point for `ryoku-shell lock`. Key fingerprint integration:
+
+### Wayland session lock
+
+```
+WlSessionLock
+  onSecureChanged:
+    if secure:
+      write qylock.locked marker
+      sddmShim.armWhenReady = true  <-- arms the sensor
+    else:
+      remove qylock.locked marker
+      sddmShim.armWhenReady = false
+      sddmShim.resetAuth()          <-- aborts PAM conversation
+```
+
+### Login success handler
+
+```
+onLoginSucceeded:
+  shellRoot.authenticated = true
+  loginctl unlock-session
+  quitTimer.start()  <-- exits the lock screen
+```
+
+## Theme (`Main.qml`)
+
+### Fingerprint hint
+
+The hint sits between the user name and the password field. It uses:
+- `mainText` color (full brightness) while scanning, not dim `subColor`
+- A pulse animation (opacity 1.0 -> 0.45 -> 1.0) while the sensor listens
+- Red (#ff4444) on failure
+- `height: 0` when invisible (clean collapse)
+
+### Race condition protection
+
+An `_unlocked` guard prevents `boomSequence.onFinished: doLogin()` from firing
+a second PAM auth if the fingerprint wins mid-windup:
+
+```
+onLoginSucceeded:
+  if fingerprintUnlock:
+    _unlocked = true
+    windupAnim.stop()
+    boomTriggerTimer.stop()
+    boomSequence.stop()    <-- kills the running animation
+    boomReveal.start()     <-- plays reveal without doLogin()
+```
+
+Without this guard, if the fingerprint wins after `boomTriggerTimer` fires
+(at 1450ms) but before `boomSequence` finishes, `doLogin()` would be called
+a second time, starting a duplicate PAM conversation.
+
+### Reveal flourish
+
+On sensor win, `boomReveal` plays the same scale/flash animation as the
+windup's reveal, but without `onFinished: doLogin()`. This gives visual
+feedback that the unlock succeeded without triggering a second auth.
+
+## Settings Page (`LockscreenPage.qml`)
+
+### Fingerprint card
+
+Under the "Sign-in & Fingerprint" collapsible section:
+
+- **Toggle**: writes `~/.config/qylock/fingerprint` (`on`/`off`)
+- **Status line**: device name, enrolled finger count
+- **Finger list**: each finger with VERIFY and DELETE buttons
+- **Actions**: ENROLL FINGERPRINT, VERIFY ANY, REMOVE ALL
+
+### Enrollment modal
+
+A dark terminal-style overlay that shows live fprintd output:
+
+- Captures **stderr** (where fprintd actually outputs)
+- Displays raw output in a monospace Flickable with auto-scroll
+- Blinking green dot while the command is running
+- ABORT/CLOSE button sends SIGTERM to the fprintd child
+
+### Finger naming
+
+After successful enrollment, the modal shows a text field where the user can
+assign a friendly name (e.g. "right index"). Names are stored in
+`~/.config/qylock/fingerprints.json` and displayed in the finger list.
+
+## Data Flow
+
+```
+~/.config/qylock/fingerprint     <-- Settings toggle ("on"/"off")
+~/.config/qylock/fingerprints.json  <-- finger name labels
+~/.local/share/quickshell-lockscreen/
+  shim/SddmShim.qml              <-- PAM + fingerprint state
+  lock_shell.qml                  <-- lock entry point
+  assets/pam/ryoku-lock           <-- PAM service
+~/.local/share/qylock/themes/
+  clockwork/orbital/Main.qml     <-- theme with sensor hint
+~/.config/quickshell/hub/pages/
+  LockscreenPage.qml              <-- Settings fingerprint card
+```

--- a/ryoku/lockscreen/fingerprint-unlock/docs/architecture.md
+++ b/ryoku/lockscreen/fingerprint-unlock/docs/architecture.md
@@ -1,217 +1,102 @@
-# Architecture: Fingerprint Unlock
+# Architecture
 
-This document explains how the fingerprint unlock feature works at every layer,
-from the PAM stack up to the theme UI.
+## The grosshack mechanism
 
-## Overview
-
-```
-+-------------------+     +-------------------+     +-------------------+
-|   Theme (QML)     |     |  SddmShim (QML)   |     |  PAM Service      |
-|   Main.qml        |<--->|  SddmShim.qml     |<--->|  ryoku-lock       |
-|                   |     |                   |     |                   |
-| - fpHint text     |     | - PamContext      |     | - grosshack pair  |
-| - fpPulse anim    |     | - fpEnabled       |     | - pam_fprintd     |
-| - boomReveal      |     | - fpHasFingers    |     | - pam_unix        |
-| - _unlocked guard |     | - armFingerprint  |     +-------------------+
-+-------------------+     | - resetAuth       |
-                          +-------------------+
-```
-
-## PAM Stack (`assets/pam/ryoku-lock`)
+`pam_fprintd_grosshack.so` is a patched `pam_fprintd`: at conversation start
+it forks `fprintd-verify` **and** presents the password prompt. The sensor
+scans while `pam_unix` waits — either success ends the conversation:
 
 ```
-auth  sufficient  pam_fprintd_grosshack.so
-auth  sufficient  pam_unix.so try_first_pass nullok
-auth  required    pam_env.so
-auth  required    pam_deny.so
-account required  pam_unix.so
-password required pam_deny.so
-session required  pam_unix.so
+auth  sufficient  pam_fprintd_grosshack.so   touch -> success
+auth  sufficient  pam_unix.so                password -> success
 ```
 
-### How grosshack works
+## PAM services
 
-`pam_fprintd_grosshack.so` is a modified version of `pam_fprintd` that forks
-`fprintd-verify` at the **start** of the PAM conversation. This means:
+| Service | File | Loaded by |
+|---|---|---|
+| lock screen | `~/.local/share/quickshell-lockscreen/assets/pam/ryoku-lock` | `PamContext.configDirectory` (no `/etc/pam.d` edit) |
+| sudo / sddm | `/etc/pam.d/sudo`, `/etc/pam.d/sddm` | one injected line via pkexec |
 
-1. The fingerprint sensor begins scanning immediately
-2. `pam_unix.so` simultaneously waits for a typed password
-3. The **first** successful auth (touch OR type) wins
-4. Both paths race in the same PAM conversation
-
-This is the same mechanism used in `/etc/pam.d/sddm`, so the behavior at the
-lock screen matches the sign-in screen exactly.
-
-### Why inline (not include)
-
-The `ryoku-lock` file lives in the lock's own `assets/pam/` directory and is
-loaded via `PamContext.configDirectory`. An `include system-login` would resolve
-against this confdir (not `/etc/pam.d`) and fail. The inline tail mirrors the
-module list the bundled DMS lock ships for its lock services.
-
-## SddmShim (`shim/SddmShim.qml`)
-
-The shim replaces the default Quickshell SDDM shim to add fingerprint support.
-It exposes the same API as a real SDDM greeter so themes work unchanged.
-
-### Properties exposed to theme
-
-| Property | Type | Source | Purpose |
-|---|---|---|---|
-| `sddm.fingerprintHint` | bool | hardcoded `true` | Gate: show the sensor hint (false under real SDDM) |
-| `sddm.fingerprintReady` | bool | `fpEnabled && fpHasFingers` | Sensor is available |
-| `sddm.fingerprintState` | string | PAM conversation | `idle` / `scanning` / `success` / `fail` |
-| `sddm.fingerprintUnlock` | bool | PAM completion | True if sensor won (not typed) |
-
-### Readiness probes
-
-Two independent probes run on lock start:
-
-1. **fpToggleProc**: reads `~/.config/qylock/fingerprint` (the Settings toggle)
-2. **fpListProc**: runs `fprintd-list` to check for enrolled fingers
-
-Both call `maybeArm()` when done. The arm only fires when ALL conditions are met:
-- Toggle is on (or file missing, default on)
-- At least one finger is enrolled
-- `armWhenReady` is true (lock surface is secured)
-- No PAM conversation is already active
-
-### PAM conversation flow
+`ryoku-lock` stack:
 
 ```
-armFingerprint()
-  -> pam.user = currentUser
-  -> pam.pendingPassword = ""
-  -> pam.start()
-  -> PAM reads ryoku-lock service
-  -> pam_fprintd_grossfork forks fprintd-verify
-  -> sensor begins scanning
-  -> fingerprintState = "scanning"
-
-  [user touches sensor]
-  -> fprintd-verify succeeds
-  -> PAM conversation completes with Success
-  -> onCompleted(PamResult.Success)
-  -> fingerprintUnlock = (scanning && !typed)
-  -> fingerprintState = "success"
-  -> sddm.loginSucceeded()
-  -> loginctl unlock-session
-
-  [OR user types password]
-  -> onResponseRequiredChanged (pam_unix prompt)
-  -> pam.respond(password)
-  -> PAM conversation completes with Success
-  -> same flow as above, but fingerprintUnlock = false
-
-  [OR scan fails]
-  -> PAM conversation completes with failure
-  -> onCompleted(non-Success)
-  -> fingerprintState = "fail"
-  -> sddm.loginFailed()
-  -> rearmTimer.restart() (700ms)
-  -> sensor re-arms for next touch
+auth        sufficient  pam_fprintd_grosshack.so
+auth        sufficient  pam_unix.so try_first_pass nullok
+auth        required    pam_env.so
+auth        required    pam_deny.so
+account     required    pam_unix.so
+password    required    pam_deny.so
+session     required    pam_unix.so
 ```
 
-## Lock Shell (`lock_shell.qml`)
+Quickshell forks a subprocess per conversation which calls
+`pam_start_confdir(config, user, conv, configDirectory)` then
+`pam_authenticate`. Signals surface as QML properties: `active`,
+`responseRequired`, `message`; results arrive in `onCompleted`
+(`PamResult.Success/Failed/MaxTries`) and failures without completion in
+`onError`.
 
-The entry point for `ryoku-shell lock`. Key fingerprint integration:
-
-### Wayland session lock
-
-```
-WlSessionLock
-  onSecureChanged:
-    if secure:
-      write qylock.locked marker
-      sddmShim.armWhenReady = true  <-- arms the sensor
-    else:
-      remove qylock.locked marker
-      sddmShim.armWhenReady = false
-      sddmShim.resetAuth()          <-- aborts PAM conversation
-```
-
-### Login success handler
+## Arm lifecycle (lock screen)
 
 ```
-onLoginSucceeded:
-  shellRoot.authenticated = true
-  loginctl unlock-session
-  quitTimer.start()  <-- exits the lock screen
+Super+L -> ryoku-shell lock -> WlSessionLock.secure == true
+    -> shim.armWhenReady = true          (onArmWhenReadyChanged)
+    -> maybeArm()                        (also called by both probes)
+         armFingerprint()
+              armPrepProc: pkill -u $USER -x fprintd-verify; sleep 0.2
+              pam.start()                ("ryoku-lock" from assets/pam)
+                  state = "scanning"     theme shows SENSOR ACTIVE
+touch -> EnrollStatus/VerifyStatus match
+       -> onCompleted(Success) -> loginSucceeded() -> reveal + unlock
+fail/timeout/error -> onCompleted(Failed) | onError
+                   -> rearmTimer (1s) -> armFingerprint() again
+unlock (secure false) -> resetAuth(): abort + state=idle
 ```
 
-## Theme (`Main.qml`)
+### Fix 1: the arm race
 
-### Fingerprint hint
+The readiness probes (`fprintd-list` + toggle file) usually finish *before*
+the compositor confirms the lock surface. If arming only happens when probes
+complete, `armWhenReady` flips true afterwards and nothing ever arms. The
+shim therefore arms on `onArmWhenReadyChanged` as well.
 
-The hint sits between the user name and the password field. It uses:
-- `mainText` color (full brightness) while scanning, not dim `subColor`
-- A pulse animation (opacity 1.0 -> 0.45 -> 1.0) while the sensor listens
-- Red (#ff4444) on failure
-- `height: 0` when invisible (clean collapse)
+### Fix 2: stale verifiers
 
-### Race condition protection
+Killing quickshell's PAM subprocess (abort/unlock) orphans the forked
+`fprintd-verify` grandchild. The orphan keeps the sensor claim, so the next
+scan cannot start — the user touches, nothing happens, and only burning a
+password cycle (fail → re-arm → fresh verifier) recovers. Every arm now runs
+`pkill -u $USER -x fprintd-verify` first.
 
-An `_unlocked` guard prevents `boomSequence.onFinished: doLogin()` from firing
-a second PAM auth if the fingerprint wins mid-windup:
+### Robustness
 
-```
-onLoginSucceeded:
-  if fingerprintUnlock:
-    _unlocked = true
-    windupAnim.stop()
-    boomTriggerTimer.stop()
-    boomSequence.stop()    <-- kills the running animation
-    boomReveal.start()     <-- plays reveal without doLogin()
-```
+- `onError` resets state instead of leaving "scanning" forever
+- finger probe retries up to 3× (fprintd is D-Bus activated, may be waking)
+- `pam.start()` failure is logged with config/dir/user context
 
-Without this guard, if the fingerprint wins after `boomTriggerTimer` fires
-(at 1450ms) but before `boomSequence` finishes, `doLogin()` would be called
-a second time, starting a duplicate PAM conversation.
+## Settings backend (hub)
 
-### Reveal flourish
+All fprintd interaction runs as the invoking user; only the sudo/SDDM
+toggles use pkexec.
 
-On sensor win, `boomReveal` plays the same scale/flash animation as the
-windup's reveal, but without `onFinished: doLogin()`. This gives visual
-feedback that the unlock succeeded without triggering a second auth.
+| Concern | Mechanism |
+|---|---|
+| enrolled fingers + sensor name | `fprintd-list $USER` (parsed) |
+| enroll progress | stage passes parsed live from stdout/stderr of `fprintd-enroll`; total from D-Bus property `num-enroll-stages` (`busctl call net.reactivated.Fprint ...`) |
+| verify | `fprintd-verify [-f finger]`, exit code cross-checked against `Verify result:` token |
+| delete | `fprintd-delete [-f finger]`; friendly-name labels in `~/.config/qylock/fingerprints.json` cleaned in sync |
+| lock toggle | `~/.config/qylock/fingerprint` (`on`/`off`) |
+| sudo/sddm toggles | `pkexec bash -c 'sed -i "1i <line>"'` to add, `sed -i '/pam_fprintd_grosshack/d'` to remove; backup written first |
 
-## Settings Page (`LockscreenPage.qml`)
+Stream parsing uses per-stream offsets so cumulative `StdioCollector` buffers
+are never counted twice. Retry statuses (`enroll-swipe-too-short`,
+`enroll-finger-not-centered`, …) map to human guidance lines in the modal.
 
-### Fingerprint card
+## Race conditions covered
 
-Under the "Sign-in & Fingerprint" collapsible section:
-
-- **Toggle**: writes `~/.config/qylock/fingerprint` (`on`/`off`)
-- **Status line**: device name, enrolled finger count
-- **Finger list**: each finger with VERIFY and DELETE buttons
-- **Actions**: ENROLL FINGERPRINT, VERIFY ANY, REMOVE ALL
-
-### Enrollment modal
-
-A dark terminal-style overlay that shows live fprintd output:
-
-- Captures **stderr** (where fprintd actually outputs)
-- Displays raw output in a monospace Flickable with auto-scroll
-- Blinking green dot while the command is running
-- ABORT/CLOSE button sends SIGTERM to the fprintd child
-
-### Finger naming
-
-After successful enrollment, the modal shows a text field where the user can
-assign a friendly name (e.g. "right index"). Names are stored in
-`~/.config/qylock/fingerprints.json` and displayed in the finger list.
-
-## Data Flow
-
-```
-~/.config/qylock/fingerprint     <-- Settings toggle ("on"/"off")
-~/.config/qylock/fingerprints.json  <-- finger name labels
-~/.local/share/quickshell-lockscreen/
-  shim/SddmShim.qml              <-- PAM + fingerprint state
-  lock_shell.qml                  <-- lock entry point
-  assets/pam/ryoku-lock           <-- PAM service
-~/.local/share/qylock/themes/
-  clockwork/orbital/Main.qml     <-- theme with sensor hint
-~/.config/quickshell/hub/pages/
-  LockscreenPage.qml              <-- Settings fingerprint card
-```
+- fingerprint wins during password windup → `_unlocked` guard in the theme;
+  reveal flourish plays without a second authentication
+- typed password during an armed scan → fed into the open conversation
+  (`pendingPassword` stash + `onResponseRequiredChanged`)
+- outside-click on the modal mid-enroll → ignored (would discard stages)

--- a/ryoku/lockscreen/fingerprint-unlock/docs/installation.md
+++ b/ryoku/lockscreen/fingerprint-unlock/docs/installation.md
@@ -1,0 +1,188 @@
+# Installation Guide
+
+## Prerequisites
+
+Before installing, verify you have:
+
+1. **fprintd** installed and running:
+   ```sh
+   systemctl status fprintd
+   ```
+
+2. **At least one finger enrolled**:
+   ```sh
+   fprintd-list $(whoami)
+   ```
+   Should show `- #0: <finger-name>`. If not, enroll one:
+   ```sh
+   fprintd-enroll
+   ```
+
+3. **pam_fprintd_grosshack.so** available (check if SDDM fingerprint works):
+   ```sh
+   find / -name "pam_fprintd_grosshack.so" 2>/dev/null
+   ```
+
+4. **Quickshell** with `Quickshell.Services.Pam` module.
+
+## Install
+
+### For testers (before merge)
+
+Install from the PR branch on the fork:
+
+```sh
+git clone https://github.com/Kavy-Codes/ryoku-arch.git -b fingerprint-unlock
+cd ryoku-arch
+./ryoku/lockscreen/fingerprint-unlock/install.sh
+systemctl --user restart ryoku-shell
+```
+
+### After merge (upstream)
+
+```sh
+cd ryoku-arch
+./ryoku/lockscreen/fingerprint-unlock/install.sh
+systemctl --user restart ryoku-shell
+```
+
+### What the installer does
+
+1. **Backs up** all existing files to `~/.ryoku-fingerprint-backups/` before overwriting
+2. **Copies** the override files to their live locations
+3. Backups preserve the original files so you can fully revert
+
+### Options
+
+```sh
+./install.sh              # install (backs up existing files first)
+./install.sh --dry-run    # show what would happen without changing anything
+./install.sh --uninstall  # restore ALL original files from backups
+```
+
+### Backup location
+
+All original files are saved to:
+
+```
+~/.ryoku-fingerprint-backups/
+  .local/share/quickshell-lockscreen/shim/SddmShim.qml
+  .local/share/quickshell-lockscreen/lock_shell.qml
+  .local/share/quickshell-lockscreen/assets/pam/ryoku-lock
+  .local/share/qylock/themes/clockwork/orbital/Main.qml
+  .config/quickshell/hub/pages/LockscreenPage.qml
+```
+
+These are the exact files that existed before install. If any didn't exist
+(e.g. `ryoku-lock` is new), no backup is created for that file.
+
+## Uninstall
+
+```sh
+./install.sh --uninstall
+systemctl --user restart ryoku-shell
+```
+
+This restores **every file** from `~/.ryoku-fingerprint-backups/` to its original
+location, completely reverting the install. The backup directory is kept (not
+deleted) so you can re-install later if needed.
+
+To fully clean up after uninstalling:
+
+```sh
+rm -rf ~/.ryoku-fingerprint-backups
+```
+
+## Manual Install (without the script)
+
+If you prefer to install manually:
+
+```sh
+# Create backup directory
+mkdir -p ~/.ryoku-fingerprint-backups
+
+# Back up existing files
+cp ~/.local/share/quickshell-lockscreen/shim/SddmShim.qml ~/.ryoku-fingerprint-backups/
+cp ~/.local/share/quickshell-lockscreen/lock_shell.qml ~/.ryoku-fingerprint-backups/
+cp ~/.local/share/quickshell-lockscreen/assets/pam/ryoku-lock ~/.ryoku-fingerprint-backups/ 2>/dev/null || true
+cp ~/.local/share/qylock/themes/clockwork/orbital/Main.qml ~/.ryoku-fingerprint-backups/
+cp ~/.config/quickshell/hub/pages/LockscreenPage.qml ~/.ryoku-fingerprint-backups/
+
+# Copy new files
+cp shim/SddmShim.qml ~/.local/share/quickshell-lockscreen/shim/
+cp lock_shell.qml ~/.local/share/quickshell-lockscreen/
+mkdir -p ~/.local/share/quickshell-lockscreen/assets/pam/
+cp assets/pam/ryoku-lock ~/.local/share/quickshell-lockscreen/assets/pam/
+cp themes/clockwork/orbital/Main.qml ~/.local/share/qylock/themes/clockwork/orbital/
+cp pages/LockscreenPage.qml ~/.config/quickshell/hub/pages/
+
+# Restart
+systemctl --user restart ryoku-shell
+```
+
+## Verify Installation
+
+```sh
+# Check the PAM service exists
+ls -la ~/.local/share/quickshell-lockscreen/assets/pam/ryoku-lock
+
+# Check fprintd is working
+fprintd-list $(whoami)
+
+# Lock and test
+loginctl lock-session
+# -> Touch the sensor or type your password
+```
+
+## Troubleshooting
+
+### "No fingerprint device found"
+
+```sh
+# Check fprintd service
+systemctl status fprintd
+
+# List devices
+fprintd-list $(whoami)
+```
+
+### "Device was already claimed"
+
+Another process is using the fingerprint sensor. Kill any running lock screen:
+
+```sh
+pkill -f "quickshell.*lock_shell"
+```
+
+### Fingerprint hint doesn't appear
+
+1. Check the toggle is on:
+   ```sh
+   cat ~/.config/qylock/fingerprint
+   # Should print "on" or the file should not exist
+   ```
+
+2. Check fingers are enrolled:
+   ```sh
+   fprintd-list $(whoami)
+   # Should show at least one finger
+   ```
+
+3. Check the PAM service exists:
+   ```sh
+   ls ~/.local/share/quickshell-lockscreen/assets/pam/ryoku-lock
+   ```
+
+### Lock screen shows QML errors
+
+Restart the shell:
+
+```sh
+systemctl --user restart ryoku-shell
+```
+
+Check logs:
+
+```sh
+journalctl --user -u ryoku-shell --since "5 min ago"
+```

--- a/ryoku/lockscreen/fingerprint-unlock/docs/installation.md
+++ b/ryoku/lockscreen/fingerprint-unlock/docs/installation.md
@@ -1,188 +1,57 @@
-# Installation Guide
+# Installation
 
 ## Prerequisites
 
-Before installing, verify you have:
+```sh
+pacman -Q fprintd quickshell          # both required
+ls /usr/lib/security/pam_fprintd_grosshack.so   # required for touch-or-type
+fprintd-list "$USER"                  # sensor found + >= 1 finger enrolled
+```
 
-1. **fprintd** installed and running:
-   ```sh
-   systemctl status fprintd
-   ```
-
-2. **At least one finger enrolled**:
-   ```sh
-   fprintd-list $(whoami)
-   ```
-   Should show `- #0: <finger-name>`. If not, enroll one:
-   ```sh
-   fprintd-enroll
-   ```
-
-3. **pam_fprintd_grosshack.so** available (check if SDDM fingerprint works):
-   ```sh
-   find / -name "pam_fprintd_grosshack.so" 2>/dev/null
-   ```
-
-4. **Quickshell** with `Quickshell.Services.Pam` module.
+No fingers enrolled yet? Run `fprintd-enroll` once, or use
+Settings → Lockscreen → Fingerprint → ENROLL FINGERPRINT after installing.
 
 ## Install
 
-### For testers (before merge)
-
-Install from the PR branch on the fork:
-
 ```sh
-git clone https://github.com/Kavy-Codes/ryoku-arch.git -b fingerprint-unlock
-cd ryoku-arch
-./ryoku/lockscreen/fingerprint-unlock/install.sh
+git clone https://github.com/Kavy-Codes/ryoku-arch.git -b fingerprint-unlock-v2
+cd ryoku-arch/ryoku/lockscreen/fingerprint-unlock
+./install.sh
 systemctl --user restart ryoku-shell
 ```
 
-### After merge (upstream)
+Files placed:
+
+| Source | Destination |
+|---|---|
+| `shim/SddmShim.qml` | `~/.local/share/quickshell-lockscreen/shim/` |
+| `lock_shell.qml` | `~/.local/share/quickshell-lockscreen/` |
+| `assets/pam/ryoku-lock` | `~/.local/share/quickshell-lockscreen/assets/pam/` |
+| `pages/LockscreenPage.qml` | `~/.config/quickshell/hub/pages/` |
+
+Existing files are backed up to `~/.ryoku-fingerprint-backups/`.
+
+Dry run first: `./install.sh --dry-run`
+
+## Uninstall / Revert
 
 ```sh
-cd ryoku-arch
-./ryoku/lockscreen/fingerprint-unlock/install.sh
+./install.sh --uninstall      # restores from ~/.ryoku-fingerprint-backups/
 systemctl --user restart ryoku-shell
 ```
 
-### What the installer does
+### Removing sudo / SDDM access
 
-1. **Backs up** all existing files to `~/.ryoku-fingerprint-backups/` before overwriting
-2. **Copies** the override files to their live locations
-3. Backups preserve the original files so you can fully revert
-
-### Options
-
-```sh
-./install.sh              # install (backs up existing files first)
-./install.sh --dry-run    # show what would happen without changing anything
-./install.sh --uninstall  # restore ALL original files from backups
-```
-
-### Backup location
-
-All original files are saved to:
-
-```
-~/.ryoku-fingerprint-backups/
-  .local/share/quickshell-lockscreen/shim/SddmShim.qml
-  .local/share/quickshell-lockscreen/lock_shell.qml
-  .local/share/quickshell-lockscreen/assets/pam/ryoku-lock
-  .local/share/qylock/themes/clockwork/orbital/Main.qml
-  .config/quickshell/hub/pages/LockscreenPage.qml
-```
-
-These are the exact files that existed before install. If any didn't exist
-(e.g. `ryoku-lock` is new), no backup is created for that file.
-
-## Uninstall
-
-```sh
-./install.sh --uninstall
-systemctl --user restart ryoku-shell
-```
-
-This restores **every file** from `~/.ryoku-fingerprint-backups/` to its original
-location, completely reverting the install. The backup directory is kept (not
-deleted) so you can re-install later if needed.
-
-To fully clean up after uninstalling:
-
-```sh
-rm -rf ~/.ryoku-fingerprint-backups
-```
-
-## Manual Install (without the script)
-
-If you prefer to install manually:
-
-```sh
-# Create backup directory
-mkdir -p ~/.ryoku-fingerprint-backups
-
-# Back up existing files
-cp ~/.local/share/quickshell-lockscreen/shim/SddmShim.qml ~/.ryoku-fingerprint-backups/
-cp ~/.local/share/quickshell-lockscreen/lock_shell.qml ~/.ryoku-fingerprint-backups/
-cp ~/.local/share/quickshell-lockscreen/assets/pam/ryoku-lock ~/.ryoku-fingerprint-backups/ 2>/dev/null || true
-cp ~/.local/share/qylock/themes/clockwork/orbital/Main.qml ~/.ryoku-fingerprint-backups/
-cp ~/.config/quickshell/hub/pages/LockscreenPage.qml ~/.ryoku-fingerprint-backups/
-
-# Copy new files
-cp shim/SddmShim.qml ~/.local/share/quickshell-lockscreen/shim/
-cp lock_shell.qml ~/.local/share/quickshell-lockscreen/
-mkdir -p ~/.local/share/quickshell-lockscreen/assets/pam/
-cp assets/pam/ryoku-lock ~/.local/share/quickshell-lockscreen/assets/pam/
-cp themes/clockwork/orbital/Main.qml ~/.local/share/qylock/themes/clockwork/orbital/
-cp pages/LockscreenPage.qml ~/.config/quickshell/hub/pages/
-
-# Restart
-systemctl --user restart ryoku-shell
-```
-
-## Verify Installation
-
-```sh
-# Check the PAM service exists
-ls -la ~/.local/share/quickshell-lockscreen/assets/pam/ryoku-lock
-
-# Check fprintd is working
-fprintd-list $(whoami)
-
-# Lock and test
-loginctl lock-session
-# -> Touch the sensor or type your password
-```
+Settings → Lockscreen → Fingerprint → toggle off **Sudo** / **Sign-in
+screen**. This deletes only the injected grosshack line; each edit also left
+a full copy at `/etc/pam.d/<svc>.ryoku-fp-bak`.
 
 ## Troubleshooting
 
-### "No fingerprint device found"
-
-```sh
-# Check fprintd service
-systemctl status fprintd
-
-# List devices
-fprintd-list $(whoami)
-```
-
-### "Device was already claimed"
-
-Another process is using the fingerprint sensor. Kill any running lock screen:
-
-```sh
-pkill -f "quickshell.*lock_shell"
-```
-
-### Fingerprint hint doesn't appear
-
-1. Check the toggle is on:
-   ```sh
-   cat ~/.config/qylock/fingerprint
-   # Should print "on" or the file should not exist
-   ```
-
-2. Check fingers are enrolled:
-   ```sh
-   fprintd-list $(whoami)
-   # Should show at least one finger
-   ```
-
-3. Check the PAM service exists:
-   ```sh
-   ls ~/.local/share/quickshell-lockscreen/assets/pam/ryoku-lock
-   ```
-
-### Lock screen shows QML errors
-
-Restart the shell:
-
-```sh
-systemctl --user restart ryoku-shell
-```
-
-Check logs:
-
-```sh
-journalctl --user -u ryoku-shell --since "5 min ago"
-```
+| Symptom | Check | Fix |
+|---|---|---|
+| hint never shows at lock | `fprintd-list $USER` shows a finger? toggle file says `on`? | enroll a finger; Settings toggle ON |
+| "touch sensor" but touch does nothing (old builds) | — | this PR fixes it; reinstall and retest |
+| unlock works only after typing a wrong password | stale `fprintd-verify` holding the claim (old builds) | fixed here by pre-arm cleanup |
+| toggles error with "cancelled?" | polkit prompt dismissed | retry, accept the prompt |
+| no enroll progress ring, only spinner | `num-enroll-stages` probe failed | harmless; ring fills on completion regardless |

--- a/ryoku/lockscreen/fingerprint-unlock/docs/testing.md
+++ b/ryoku/lockscreen/fingerprint-unlock/docs/testing.md
@@ -1,0 +1,104 @@
+# Testing Checklist
+
+## Prerequisites
+
+- [ ] `fprintd` is installed and running (`systemctl status fprintd`)
+- [ ] At least one finger is enrolled (`fprintd-list $(whoami)` shows entries)
+- [ ] `pam_fprintd_grosshack.so` is available
+- [ ] Quickshell is installed with `Quickshell.Services.Pam`
+
+## Installation
+
+- [ ] Run `./install.sh --dry-run` and verify the output
+- [ ] Run `./install.sh` and verify files are copied
+- [ ] Verify backups exist in `~/.ryoku-fingerprint-backups/`
+- [ ] Run `systemctl --user restart ryoku-shell` without errors
+
+## Settings Page
+
+- [ ] Open Ryoku Settings -> Lockscreen
+- [ ] Expand "Sign-in & Fingerprint" section
+- [ ] Fingerprint card shows device name and enrolled finger count
+- [ ] Toggle "Unlock with fingerprint" Off -> On
+- [ ] Toggle writes `~/.config/qylock/fingerprint` correctly
+- [ ] ENROLL FINGERPRINT button opens the terminal modal
+- [ ] Terminal modal shows live fprintd output
+- [ ] Enrollment completes successfully
+- [ ] Naming prompt appears after enrollment
+- [ ] VERIFY button works for each enrolled finger
+- [ ] DELETE button removes a finger
+- [ ] REMOVE ALL removes all fingers (with confirm)
+
+## Lock Screen - Fingerprint
+
+- [ ] Lock: `loginctl lock-session` or `Super+L`
+- [ ] Sensor hint appears ("SENSOR ACTIVE / TOUCH OR TYPE")
+- [ ] Hint has a pulse animation while scanning
+- [ ] Touch the sensor: unlocks immediately (reveal plays)
+- [ ] No password prompt appears on touch unlock
+
+## Lock Screen - Password
+
+- [ ] Lock again
+- [ ] Type password and press Enter
+- [ ] Password still works while sensor is scanning
+- [ ] "ACCESS DENIED" appears on wrong password
+
+## Lock Screen - Toggle Off
+
+- [ ] Settings -> Lockscreen -> Fingerprint -> Toggle Off
+- [ ] Lock the screen
+- [ ] No sensor hint appears
+- [ ] Password-only unlock works
+
+## Race Condition
+
+- [ ] Lock the screen
+- [ ] Start typing a password (but don't press Enter yet)
+- [ ] Touch the sensor while typing
+- [ ] Only one unlock happens (no double auth)
+- [ ] No QML errors in journal
+
+## SDDM Greeter
+
+- [ ] Log out completely
+- [ ] SDDM greeter appears (unchanged)
+- [ ] Fingerprint still works at the greeter (if it did before)
+- [ ] Greeter does NOT show the sensor hint (in-session only)
+
+## Uninstall
+
+- [ ] Run `./install.sh --uninstall`
+- [ ] Verify original files are restored from backups
+- [ ] Run `systemctl --user restart ryoku-shell`
+- [ ] Lock screen works without fingerprint (password only)
+- [ ] Settings -> Lockscreen no longer shows fingerprint card
+
+## Edge Cases
+
+- [ ] Lock while no finger is enrolled -> no sensor hint
+- [ ] Lock while fprintd is stopped -> no sensor hint
+- [ ] Enroll a new finger while lock is active -> re-arm works
+- [ ] Delete all fingers while lock is active -> hint disappears
+- [ ] Multiple rapid lock/unlock cycles -> no stale state
+- [ ] Reboot after install -> everything still works
+
+## Logs
+
+Check for QML errors:
+
+```sh
+journalctl --user -u ryoku-shell --since "5 min ago" | grep -i "error\|qml"
+```
+
+Check fprintd:
+
+```sh
+journalctl -u fprintd --since "5 min ago"
+```
+
+Check PAM:
+
+```sh
+journalctl --since "5 min ago" | grep -i "pam\|fprint"
+```

--- a/ryoku/lockscreen/fingerprint-unlock/docs/testing.md
+++ b/ryoku/lockscreen/fingerprint-unlock/docs/testing.md
@@ -1,104 +1,45 @@
 # Testing Checklist
 
-## Prerequisites
+Run `./install.sh`, then `systemctl --user restart ryoku-shell`.
+Enroll one finger first (Settings → Lockscreen → Fingerprint).
 
-- [ ] `fprintd` is installed and running (`systemctl status fprintd`)
-- [ ] At least one finger is enrolled (`fprintd-list $(whoami)` shows entries)
-- [ ] `pam_fprintd_grosshack.so` is available
-- [ ] Quickshell is installed with `Quickshell.Services.Pam`
+## 1. Enrollment
 
-## Installation
+- [ ] ENROLL FINGERPRINT opens the modal; ring spins while waiting
+- [ ] each accepted touch advances the ring (`n/total`); total appears within ~2s
+- [ ] lifting early shows retry guidance ("lift and touch again", "too short", ...)
+- [ ] completion swaps the ring for a check and asks to name the print
+- [ ] SAVE stores the label; SKIP stores the raw name; both close + refresh list
 
-- [ ] Run `./install.sh --dry-run` and verify the output
-- [ ] Run `./install.sh` and verify files are copied
-- [ ] Verify backups exist in `~/.ryoku-fingerprint-backups/`
-- [ ] Run `systemctl --user restart ryoku-shell` without errors
+## 2. Lock screen (the core fix)
 
-## Settings Page
+- [ ] lock (`Super+L` or `loginctl lock-session`)
+- [ ] hint appears **without touching anything**: pulsing "SENSOR ACTIVE · TOUCH OR TYPE"
+- [ ] touch once → reveal plays, session unlocks (no Enter, no password)
+- [ ] lock again → type the password instead → unlocks mid-scan
+- [ ] lock again → wrong password → ACCESS DENIED → sensor re-arms by itself
+- [ ] repeat lock/unlock 5×: every fresh lock accepts touch on the FIRST try
 
-- [ ] Open Ryoku Settings -> Lockscreen
-- [ ] Expand "Sign-in & Fingerprint" section
-- [ ] Fingerprint card shows device name and enrolled finger count
-- [ ] Toggle "Unlock with fingerprint" Off -> On
-- [ ] Toggle writes `~/.config/qylock/fingerprint` correctly
-- [ ] ENROLL FINGERPRINT button opens the terminal modal
-- [ ] Terminal modal shows live fprintd output
-- [ ] Enrollment completes successfully
-- [ ] Naming prompt appears after enrollment
-- [ ] VERIFY button works for each enrolled finger
-- [ ] DELETE button removes a finger
-- [ ] REMOVE ALL removes all fingers (with confirm)
+## 3. Sudo / SDDM toggles
 
-## Lock Screen - Fingerprint
+- [ ] polkit prompt appears on toggle; cancelling shows a gentle error, state unchanged
+- [ ] sudo ON: `sudo -k && sudo true` → touch works; OFF: back to password
+- [ ] `/etc/pam.d/sudo.ryoku-fp-bak` exists after first change
+- [ ] toggle state survives page reopen (grep-based status read)
+- [ ] a pre-existing grosshack line in `/etc/pam.d/sddm` shows ON before any click
+- [ ] removal deletes only the grosshack line (diff against the `.ryoku-fp-bak`)
 
-- [ ] Lock: `loginctl lock-session` or `Super+L`
-- [ ] Sensor hint appears ("SENSOR ACTIVE / TOUCH OR TYPE")
-- [ ] Hint has a pulse animation while scanning
-- [ ] Touch the sensor: unlocks immediately (reveal plays)
-- [ ] No password prompt appears on touch unlock
+## 4. Prints management
 
-## Lock Screen - Password
+- [ ] two-step delete: ✕ → SURE? (3s window) → removed; label gone from list too
+- [ ] REMOVE ALL same pattern; list empties, empty-state text appears
+- [ ] VERIFY per finger and VERIFY ALL show MATCH / NO MATCH plate; auto-closes on match
+- [ ] friendly names survive hub restarts (`~/.config/qylock/fingerprints.json`)
 
-- [ ] Lock again
-- [ ] Type password and press Enter
-- [ ] Password still works while sensor is scanning
-- [ ] "ACCESS DENIED" appears on wrong password
+## 5. Regression / edge cases
 
-## Lock Screen - Toggle Off
-
-- [ ] Settings -> Lockscreen -> Fingerprint -> Toggle Off
-- [ ] Lock the screen
-- [ ] No sensor hint appears
-- [ ] Password-only unlock works
-
-## Race Condition
-
-- [ ] Lock the screen
-- [ ] Start typing a password (but don't press Enter yet)
-- [ ] Touch the sensor while typing
-- [ ] Only one unlock happens (no double auth)
-- [ ] No QML errors in journal
-
-## SDDM Greeter
-
-- [ ] Log out completely
-- [ ] SDDM greeter appears (unchanged)
-- [ ] Fingerprint still works at the greeter (if it did before)
-- [ ] Greeter does NOT show the sensor hint (in-session only)
-
-## Uninstall
-
-- [ ] Run `./install.sh --uninstall`
-- [ ] Verify original files are restored from backups
-- [ ] Run `systemctl --user restart ryoku-shell`
-- [ ] Lock screen works without fingerprint (password only)
-- [ ] Settings -> Lockscreen no longer shows fingerprint card
-
-## Edge Cases
-
-- [ ] Lock while no finger is enrolled -> no sensor hint
-- [ ] Lock while fprintd is stopped -> no sensor hint
-- [ ] Enroll a new finger while lock is active -> re-arm works
-- [ ] Delete all fingers while lock is active -> hint disappears
-- [ ] Multiple rapid lock/unlock cycles -> no stale state
-- [ ] Reboot after install -> everything still works
-
-## Logs
-
-Check for QML errors:
-
-```sh
-journalctl --user -u ryoku-shell --since "5 min ago" | grep -i "error\|qml"
-```
-
-Check fprintd:
-
-```sh
-journalctl -u fprintd --since "5 min ago"
-```
-
-Check PAM:
-
-```sh
-journalctl --since "5 min ago" | grep -i "pam\|fprint"
-```
+- [ ] fingerprint disabled (toggle off): lock shows no hint, password only
+- [ ] no fingers enrolled: prints column explains itself; enroll still offered
+- [ ] fprintd stopped (`systemctl stop fprintd`): section says so, RETRY works
+- [ ] SDDM greeter sign-in unaffected by the settings changes
+- [ ] Escape closes the modal when idle; ABORT stops enroll mid-run

--- a/ryoku/lockscreen/fingerprint-unlock/install.sh
+++ b/ryoku/lockscreen/fingerprint-unlock/install.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# fingerprint-unlock: install / uninstall Ryoku fingerprint unlock overrides
+#
+# Usage:
+#   ./install.sh              install (backs up existing files)
+#   ./install.sh --uninstall  restore from backups
+#   ./install.sh --dry-run    show what would happen
+#
+# Requires: fprintd, fprintd-list (the user must have at least one finger
+# enrolled for the lock to offer sensor unlock).
+
+set -euo pipefail
+
+DRY=0
+UNINSTALL=0
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run)  DRY=1 ;;
+        --uninstall) UNINSTALL=1 ;;
+        --help|-h)  echo "Usage: $0 [--dry-run] [--uninstall]"; exit 0 ;;
+    esac
+done
+
+# Paths
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCKSCREEN_DIR="$HOME/.local/share/quickshell-lockscreen"
+THEME_DIR="$HOME/.local/share/qylock/themes/clockwork/orbital"
+HUB_DIR="$HOME/.config/quickshell/hub/pages"
+BACKUP_DIR="$HOME/.ryoku-fingerprint-backups"
+
+# Files to install (source -> dest)
+declare -A FILES=(
+    ["$SCRIPT_DIR/shim/SddmShim.qml"]="$LOCKSCREEN_DIR/shim/SddmShim.qml"
+    ["$SCRIPT_DIR/lock_shell.qml"]="$LOCKSCREEN_DIR/lock_shell.qml"
+    ["$SCRIPT_DIR/assets/pam/ryoku-lock"]="$LOCKSCREEN_DIR/assets/pam/ryoku-lock"
+    ["$SCRIPT_DIR/themes/clockwork/orbital/Main.qml"]="$THEME_DIR/Main.qml"
+    ["$SCRIPT_DIR/pages/LockscreenPage.qml"]="$HUB_DIR/LockscreenPage.qml"
+)
+
+backup_file() {
+    local dest="$1"
+    if [ -f "$dest" ]; then
+        local rel="${dest#$HOME/}"
+        local bak="$BACKUP_DIR/$rel"
+        mkdir -p "$(dirname "$bak")"
+        if [ "$DRY" -eq 1 ]; then
+            echo "  backup: $dest -> $bak"
+        else
+            cp "$dest" "$bak"
+            echo "  backed up: $dest"
+        fi
+    fi
+}
+
+install_file() {
+    local src="$1" dest="$2"
+    mkdir -p "$(dirname "$dest")"
+    if [ "$DRY" -eq 1 ]; then
+        echo "  install: $src -> $dest"
+    else
+        cp "$src" "$dest"
+        echo "  installed: $dest"
+    fi
+}
+
+restore_file() {
+    local dest="$1"
+    local rel="${dest#$HOME/}"
+    local bak="$BACKUP_DIR/$rel"
+    if [ -f "$bak" ]; then
+        if [ "$DRY" -eq 1 ]; then
+            echo "  restore: $bak -> $dest"
+        else
+            cp "$bak" "$dest"
+            echo "  restored: $dest"
+        fi
+    elif [ "$DRY" -eq 1 ]; then
+        echo "  skip (no backup): $dest"
+    fi
+}
+
+echo "=== Ryoku Fingerprint Unlock ==="
+echo ""
+
+if [ "$UNINSTALL" -eq 1 ]; then
+    echo "Restoring from backups in $BACKUP_DIR ..."
+    for dest in "${FILES[@]}"; do
+        restore_file "$dest"
+    done
+    echo ""
+    echo "Done. Restart the shell: systemctl --user restart ryoku-shell"
+    echo "Backups kept in: $BACKUP_DIR"
+    exit 0
+fi
+
+# Preflight: check fprintd
+if ! command -v fprintd-list &>/dev/null; then
+    echo "WARNING: fprintd-list not found. Install fprintd for fingerprint support."
+fi
+
+# Check enrolled fingers
+FINGER_COUNT=0
+if command -v fprintd-list &>/dev/null; then
+    FP_OUTPUT=$(fprintd-list "$(whoami)" 2>/dev/null || true)
+    FINGER_COUNT=$(echo "$FP_OUTPUT" | grep -c "^ - #" || true)
+fi
+
+if [ "$FINGER_COUNT" -eq 0 ]; then
+    echo "WARNING: No fingers enrolled. Run 'fprintd-enroll' first."
+    echo ""
+fi
+
+echo "Backing up existing files to $BACKUP_DIR ..."
+for dest in "${FILES[@]}"; do
+    backup_file "$dest"
+done
+
+echo ""
+echo "Installing fingerprint unlock overrides ..."
+for src in "${!FILES[@]}"; do
+    install_file "$src" "${FILES[$src]}"
+done
+
+echo ""
+echo "=== Installed ==="
+echo ""
+echo "Files changed:"
+for dest in "${FILES[@]}"; do
+    echo "  $dest"
+done
+echo ""
+echo "Backups: $BACKUP_DIR"
+echo "  Restore with: $0 --uninstall"
+echo ""
+echo "Restart the shell: systemctl --user restart ryoku-shell"
+echo "Test with: loginctl lock-session"

--- a/ryoku/lockscreen/qylock/quickshell-lockscreen/assets/pam/ryoku-lock
+++ b/ryoku/lockscreen/qylock/quickshell-lockscreen/assets/pam/ryoku-lock
@@ -1,0 +1,41 @@
+#%PAM-1.0
+# Ryoku in-session lock PAM service
+#
+# This is the PAM stack for the Ryoku lock screen's fingerprint unlock.
+# It lives in the lock's own assets/pam/ directory and is loaded by
+# PamContext.configDirectory, so NO root edit of /etc/pam.d is needed.
+#
+# HOW THE GROSSHACK WORKS:
+#   pam_fprintd_grosshack.so is a modified version of pam_fprintd that
+#   forks fprintd-verify at the START of the PAM conversation. This means:
+#
+#   1. The fingerprint sensor begins scanning immediately
+#   2. pam_unix.so simultaneously waits for a typed password
+#   3. The FIRST successful auth (touch OR type) wins
+#   4. Both paths race in the same PAM conversation
+#
+#   This is the same mechanism used in /etc/pam.d/sddm, so the behavior
+#   at the lock screen matches the sign-in screen exactly.
+#
+# WHY INLINE (not include):
+#   This file is loaded from the lock's assets/pam/ confdir, NOT from
+#   /etc/pam.d/. An `include system-login` would resolve against this
+#   confdir and fail. The inline tail mirrors the module list the
+#   bundled DMS lock ships for its lock services.
+#
+# MODULE STACK:
+#   auth  sufficient  pam_fprintd_grosshack.so  <- touch-to-unlock
+#   auth  sufficient  pam_unix.so               <- typed password
+#   auth  required    pam_env.so                <- load env
+#   auth  required    pam_deny.so               <- deny if neither matched
+#   account required  pam_unix.so               <- account validation
+#   password required pam_deny.so               <- no password changes
+#   session required  pam_unix.so               <- session setup
+
+auth        sufficient  pam_fprintd_grosshack.so
+auth        sufficient  pam_unix.so try_first_pass nullok
+auth        required    pam_env.so
+auth        required    pam_deny.so
+account     required    pam_unix.so
+password    required    pam_deny.so
+session     required    pam_unix.so

--- a/ryoku/lockscreen/qylock/quickshell-lockscreen/lock_shell.qml
+++ b/ryoku/lockscreen/qylock/quickshell-lockscreen/lock_shell.qml
@@ -1,16 +1,35 @@
+// lock_shell.qml - Ryoku in-session lock screen
+//
+// This is the entry point for the lock screen launched by `ryoku-shell lock`.
+// It creates a Wayland session lock (or X11 fullscreen window) and loads the
+// selected qylock theme (default: clockwork/orbital).
+//
+// Fingerprint integration:
+//   - The SddmShim provides PAM and fingerprint state
+//   - When WlSessionLock.secure becomes true, armWhenReady is set
+//   - The shim probes fprintd and arms the sensor automatically
+//   - On loginSucceeded, loginctl unlock-session is called
+//   - On unlock (secure flips false), resetAuth() stops the sensor
+
 import QtQuick
 import Quickshell
 import Quickshell.Wayland
 import QtMultimedia
 import "./shim"
 
-
 ShellRoot {
     id: shellRoot
 
+    // ── theme configuration ────────────────────────────────────────────────
+    // QS_THEME and QS_THEME_PATH are set by lock.sh, which reads
+    // ~/.config/qylock/theme and resolves the theme directory.
     property string activeTheme: Quickshell.env("QS_THEME") || "clockwork/orbital"
     property string themePath: Quickshell.env("QS_THEME_PATH") || (Quickshell.shellDir + "/themes_link/" + activeTheme)
 
+    // ── shim interface ──────────────────────────────────────────────────────
+    // Expose the SddmShim's properties to the theme via the sddm namespace.
+    // Themes bind to sddm.login(), sddm.loginSucceeded, sddm.loginFailed,
+    // sddm.hostName, sddm.fingerprintHint, etc.
     readonly property var sddm: sddmShim.sddm
     readonly property var config: sddmShim.config
     readonly property var userModel: sddmShim.userModel
@@ -26,18 +45,23 @@ ShellRoot {
         themePath: shellRoot.themePath
     }
 
+    // ── login success handler ───────────────────────────────────────────────
+    // Called by the shim when PAM authentication succeeds (either via fingerprint
+    // or typed password). Unlocks the session and quits the lock screen.
     Connections {
         target: sddmShim.sddm
         function onLoginSucceeded() {
             shellRoot.authenticated = true
 
-            // Hyprland session lock fix
+            // Hyprland session lock fix: allow the compositor to restore
+            // the previous layout after the lock surface is destroyed.
             if (Quickshell.env("XDG_CURRENT_DESKTOP") === "Hyprland" || Quickshell.env("HYPRLAND_INSTANCE_SIGNATURE") !== "") {
                 Quickshell.execDetached(["hyprctl", "keyword", "misc:allow_session_lock_restore", "1"]);
             }
             Quickshell.execDetached(["loginctl", "unlock-session"]);
 
-            // Dynamic exit delay
+            // Dynamic exit delay: clockwork themes with windup animation
+            // need a longer delay so the reveal animation completes.
             let delay = 100;
             if (activeTheme.includes("clockwork") && sddmShim.config.enableWindup === "true") {
                 delay = 500;
@@ -56,15 +80,14 @@ ShellRoot {
         }
     }
 
+    // ── theme loader ────────────────────────────────────────────────────────
+    // Loads the selected theme's Main.qml into a fullscreen surface.
     Component {
         id: themeComponent
         Loader {
             anchors.fill: parent
             source: "file://" + shellRoot.themePath + "/Main.qml"
-            
-            onLoaded: {
-                item.forceActiveFocus()
-            }
+            onLoaded: { item.forceActiveFocus() }
             onStatusChanged: {
                 if (status === Loader.Error) {
                     console.error("FAILED to load theme:", source)
@@ -73,6 +96,10 @@ ShellRoot {
         }
     }
 
+    // ── Wayland session lock ────────────────────────────────────────────────
+    // Uses Quickshell's WlSessionLock to cover all outputs with a secure
+    // surface. The lock is confirmed (secure=true) once the compositor
+    // acknowledges every output is covered.
     Loader {
         id: waylandLoader
         active: shellRoot.isWayland
@@ -80,26 +107,31 @@ ShellRoot {
             WlSessionLock {
                 id: lock
                 locked: shellRoot.sessionLocked
-                // ryoku-shell's `lock` command blocks on this marker so
-                // hypridle's before_sleep_cmd only returns once the compositor
-                // confirms every output is covered (no desktop flash on
-                // resume). secure flips false on unlock; remove it then so a
-                // later lock never reads stale state.
+
+                // onSecureChanged fires when the compositor confirms the lock.
+                // We use this to:
+                //   1. Write the qylock.locked marker (so ryoku-shell blocks)
+                //   2. Arm the fingerprint sensor (armWhenReady = true)
+                // On unlock, we clean up the marker and abort any PAM conversation.
                 onSecureChanged: {
                     if (lock.secure) {
                         Quickshell.execDetached(["sh", "-c", "umask 077; : > \"${XDG_RUNTIME_DIR:-/tmp}/qylock.locked\""])
+                        sddmShim.armWhenReady = true
                     } else {
                         Quickshell.execDetached(["sh", "-c", "rm -f \"${XDG_RUNTIME_DIR:-/tmp}/qylock.locked\""])
+                        sddmShim.armWhenReady = false
+                        sddmShim.resetAuth()
                     }
                 }
+
                 surface: Component {
                     WlSessionLockSurface {
                         color: "black"
-                        
-                        // Absorb unhandled gestures
+
+                        // Absorb unhandled gestures (scroll, pinch) so they
+                        // don't leak through to the desktop underneath.
                         PinchHandler { target: null }
                         WheelHandler { target: null }
-                        
                         MouseArea {
                             anchors.fill: parent
                             acceptedButtons: Qt.AllButtons
@@ -117,6 +149,9 @@ ShellRoot {
         }
     }
 
+    // ── X11 fallback ────────────────────────────────────────────────────────
+    // On X11 sessions, use fullscreen windows instead of WlSessionLock.
+    // Each screen gets its own lock window.
     Loader {
         id: x11Loader
         active: !shellRoot.isWayland
@@ -131,14 +166,11 @@ ShellRoot {
                     height: isTesting ? 720 : screen.height
                     visible: shellRoot.sessionLocked
                     visibility: isTesting ? Window.Windowed : Window.FullScreen
-                    
                     onClosing: (close) => {
                         close.accepted = shellRoot.authenticated || shellRoot.isTesting;
                     }
-                    
                     flags: Qt.WindowStaysOnTopHint | Qt.FramelessWindowHint | Qt.MaximizeUsingFullscreenGeometryHint
                     color: "black"
-
                     Loader {
                         anchors.fill: parent
                         sourceComponent: themeComponent

--- a/ryoku/lockscreen/qylock/quickshell-lockscreen/shim/SddmShim.qml
+++ b/ryoku/lockscreen/qylock/quickshell-lockscreen/shim/SddmShim.qml
@@ -1,3 +1,26 @@
+// SddmShim.qml - Quickshell shim for Ryoku in-session lock
+//
+// This file replaces the default Quickshell SDDM shim to add fingerprint
+// unlock support via pam_fprintd_grosshack.so. It exposes the same API as
+// a real SDDM greeter (login, reboot, powerOff, suspend, userModel,
+// sessionModel, keyboard) so themes work unchanged, plus fingerprint state
+// properties that the theme reads to show a sensor hint.
+//
+// How it works:
+//   1. On lock, lock_shell.qml sets armWhenReady = true
+//   2. This shim probes fprintd-list and reads ~/.config/qylock/fingerprint
+//   3. If fingerprint is enabled and fingers are enrolled, armFingerprint()
+//      starts a PAM conversation with the ryoku-lock service
+//   4. pam_fprintd_grosshack.so forks fprintd-verify at conversation start,
+//      so the sensor scans while pam_unix waits for a password
+//   5. Either success unlocks within the SAME conversation
+//   6. A failed scan triggers a 700ms re-arm timer for the next touch
+//
+// PAM flow (touch OR type):
+//   pam_fprintd_grosshack.so  ->  sensor scan  ->  success = unlock
+//   pam_unix.so                ->  password     ->  success = unlock
+//   pam_deny.so               ->  neither      ->  fail + re-arm
+
 import QtQuick
 import Quickshell
 import Quickshell.Io
@@ -6,11 +29,27 @@ import Quickshell.Services.Pam
 Item {
     id: shim
 
+    // ── theme configuration ────────────────────────────────────────────────
     property string themePath: ""
     property var config: ({})
     property bool configReady: false
     property string hostName: "localhost"
 
+    // ── fingerprint unlock state ────────────────────────────────────────────
+    // These properties are read at lock start and updated live. The theme
+    // binds to sddm.fingerprintHint, sddm.fingerprintReady,
+    // sddm.fingerprintState, and sddm.fingerprintUnlock to show the sensor
+    // hint and play the reveal flourish.
+    property bool fpEnabled: true            // from ~/.config/qylock/fingerprint
+    property bool fpHasFingers: false        // fprintd-list reports >= 1 finger
+    readonly property bool fingerprintReady: fpEnabled && fpHasFingers
+    property string fingerprintState: "idle" // idle | scanning | success | fail
+    property bool fingerprintUnlock: false   // true if sensor won (not typed)
+    property bool armWhenReady: false        // lock surface is secured, arm now
+    property bool fpTyped: false             // a key was fed to the conversation
+
+    // ── theme config loader ─────────────────────────────────────────────────
+    // Parses theme.conf (key=value format) from the theme directory.
     function loadConfig(path) {
         if (!path) {
             config = { background: "bg.png" };
@@ -33,7 +72,6 @@ Item {
                         }
                     }
                 }
-                // Default background fallback
                 if (!newConfig.background) {
                     newConfig.background = "bg.png";
                 }
@@ -51,16 +89,15 @@ Item {
         }
     }
 
+    // ── user model ──────────────────────────────────────────────────────────
+    // Single-user model for the lock screen. The real SDDM greeter enumerates
+    // all system users; the in-session lock only needs the current user.
     property var userModel: ListModel {
         id: internalUserModel
         property string lastUser: Quickshell.env("USER") || "traveler"
         property int lastIndex: 0
         function rowCount() { return count; }
-
-        function index(row, col) {
-            return row;
-        }
-
+        function index(row, col) { return row; }
         function data(row, role) {
             var item = get(row);
             if (!item) return "";
@@ -68,7 +105,6 @@ Item {
             if (role === (Qt.UserRole + 2)) return item.realName;
             return item.name;
         }
-
         Component.onCompleted: {
             append({
                 name: Quickshell.env("USER") || "traveler",
@@ -79,6 +115,8 @@ Item {
         }
     }
 
+    // ── session model ───────────────────────────────────────────────────────
+    // Enumerates available desktop sessions from /usr/share/*-sessions/.
     property var sessionModel: ListModel {
         id: internalSessionModel
         property int lastIndex: 0
@@ -90,12 +128,10 @@ Item {
             return item.name;
         }
         Component.onCompleted: {
-            // Initial session placeholder
             append({ name: "Session", file: "" });
         }
     }
 
-    // Enumerate system sessions
     Process {
         id: sessionEnumerator
         command: [
@@ -107,15 +143,10 @@ Item {
             "echo \"$NAME|||$FILE\"; " +
             "fi; done"
         ]
-
         stdout: StdioCollector {
-            onStreamFinished: {
-                shim.parseSessions(this.text);
-            }
+            onStreamFinished: { shim.parseSessions(this.text); }
         }
-
         onExited: (exitCode, exitStatus) => {
-            // No sessions fallback
             if (internalSessionModel.count === 0) {
                 internalSessionModel.append({ name: "Unknown", file: "unknown.desktop" });
             }
@@ -128,22 +159,17 @@ Item {
             internalSessionModel.append({ name: "Session", file: "unknown.desktop" });
             return;
         }
-
         internalSessionModel.clear();
         var lines = output.trim().split("\n");
         var currentDesktop = (Quickshell.env("XDG_SESSION_DESKTOP") || Quickshell.env("DESKTOP_SESSION") || "").toLowerCase();
         var bestIndex = 0;
         var added = 0;
-
         for (var i = 0; i < lines.length; i++) {
             var line = lines[i].trim();
             if (line === "") continue;
-
             var parts = line.split("|||");
             if (parts.length === 2 && parts[0] !== "" && parts[1] !== "") {
                 internalSessionModel.append({ name: parts[0], file: parts[1] });
-                
-                // Match current desktop
                 var fileName = parts[1].toLowerCase();
                 if (currentDesktop !== "" && (fileName.indexOf(currentDesktop) !== -1 || currentDesktop.indexOf(fileName.replace(".desktop", "")) !== -1)) {
                     bestIndex = added;
@@ -151,8 +177,6 @@ Item {
                 added++;
             }
         }
-
-        // Fallback for sessions
         if (added === 0) {
             internalSessionModel.append({ name: "Unknown", file: "unknown.desktop" });
         } else {
@@ -160,17 +184,45 @@ Item {
         }
     }
 
+    // ── SDDM-compatible interface ───────────────────────────────────────────
+    // Themes bind to sddm.login(), sddm.hostName, sddm.loginSucceeded,
+    // sddm.loginFailed, etc. Under a real SDDM greeter these are provided by
+    // the greeter; under the lock screen this shim provides them.
     property var sddm: QtObject {
-        // Ryoku: report a hostName so skins' isQuickshell test (which keys off
-        // sddm.hostName being undefined) evaluates false. Skins like material-you
-        // and nothing gate login and power behind `!isQuickshell`; since the shim
-        // implements those actions it must present as a capable backend, not a stub.
         property string hostName: shim.hostName
         signal loginFailed()
         signal loginSucceeded()
 
+        // Fingerprint properties exposed to the theme. Under a real SDDM
+        // greeter these are undefined, so theme gates on them evaluate false
+        // and the greeter is visually untouched. Under this shim they drive
+        // the sensor hint.
+        readonly property bool fingerprintHint: true
+        property bool fingerprintReady: shim.fingerprintReady
+        property string fingerprintState: shim.fingerprintState
+        property bool fingerprintUnlock: shim.fingerprintUnlock
+
+        // login() is called by the theme when the user submits a password.
+        // If a grosshack conversation is already active (the sensor is live),
+        // the typed key is fed into it instead of starting a new conversation.
         function login(user, password, sessionIndex) {
             pam.user = user;
+            if (pam.active) {
+                // Already inside an armed grosshack conversation: feed this
+                // key instead of restarting the scan. The open prompt may
+                // already be waiting, so respond immediately; otherwise stash
+                // it and onResponseRequiredChanged sends it on arrival.
+                if (pam.responseRequired) {
+                    shim.fpTyped = true;
+                    pam.respond(password);
+                    pam.pendingPassword = "";
+                } else {
+                    pam.pendingPassword = password;
+                }
+                return;
+            }
+            shim.fpTyped = false;
+            shim.fingerprintState = "idle";
             pam.pendingPassword = password;
             pam.start();
         }
@@ -180,16 +232,17 @@ Item {
         function suspend() { Quickshell.execDetached(["bash", "-c", "if [ -d /run/systemd/system ]; then systemctl suspend; else loginctl suspend; fi"]); }
     }
 
-    // SDDM exposes a writable `keyboard` carrying the lock-key state; skins set
-    // `keyboard.numLock = true` so the numpad works. Provide it so the assignment
-    // resolves instead of raising a ReferenceError.
+    // SDDM exposes a writable `keyboard` carrying the lock-key state; skins
+    // set `keyboard.numLock = true` so the numpad works. Provide it so the
+    // assignment resolves instead of raising a ReferenceError.
     property var keyboard: QtObject {
         property bool numLock: false
         property bool capsLock: false
     }
 
-    // Resolve the real hostname for sddm.hostName; the "localhost" default above
-    // keeps the isQuickshell test correct until this returns.
+    // ── hostname resolver ───────────────────────────────────────────────────
+    // Resolve the real hostname for sddm.hostName; the "localhost" default
+    // above keeps the isQuickshell test correct until this returns.
     Process {
         id: hostnameProc
         command: ["cat", "/etc/hostname"]
@@ -201,28 +254,156 @@ Item {
         }
     }
 
+    // ── fingerprint readiness probes ────────────────────────────────────────
+    // Two independent probes determine if the sensor is available:
+    //   1. fpToggleProc reads ~/.config/qylock/fingerprint (the Settings toggle)
+    //   2. fpListProc runs fprintd-list to check for enrolled fingers
+    // Both call maybeArm() when done, which starts the PAM conversation if
+    // all conditions are met.
+
+    // Read the Settings toggle (missing file = enabled).
+    Process {
+        id: fpToggleProc
+        command: [
+            "bash", "-c",
+            "if [ -f \"$HOME/.config/qylock/fingerprint\" ]; then cat \"$HOME/.config/qylock/fingerprint\"; else printf 'on'; fi"
+        ]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                var v = this.text.trim().toLowerCase();
+                shim.fpEnabled = !(v === "off" || v === "0" || v === "false");
+                shim.maybeArm();
+            }
+        }
+    }
+
+    // Probe enrolled fingers; the lock only offers the sensor when this user
+    // actually has one stored.
+    Process {
+        id: fpListProc
+        command: ["fprintd-list", Quickshell.env("USER") || "traveler"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                var txt = this.text || "";
+                var hasDev = txt.indexOf("Using device") !== -1 || txt.indexOf("Device at") !== -1 || txt.indexOf("found ") !== -1;
+                var n = 0;
+                var lines = txt.split("\n");
+                for (var i = 0; i < lines.length; i++) {
+                    if (lines[i].trim().indexOf("- #") === 0)
+                        n++;
+                }
+                shim.fpHasFingers = hasDev && n > 0;
+                shim.maybeArm();
+            }
+        }
+        onExited: (code) => {
+            if (code !== 0) {
+                shim.fpHasFingers = false;
+                shim.maybeArm();
+            }
+        }
+    }
+
+    // ── PAM conversation ────────────────────────────────────────────────────
+    // The core of the fingerprint unlock: a single PamContext using the
+    // ryoku-lock PAM service. This service contains the grosshack pair:
+    //   - pam_fprintd_grosshack.so forks fprintd-verify at conversation start
+    //   - pam_unix.so waits for a typed password
+    //   - Either success unlocks within the SAME conversation
+    //
+    // The config is a relative path ("ryoku-lock"), resolved against
+    // configDirectory which points to <lock_dir>/assets/pam/. This means
+    // no root edit of /etc/pam.d is needed -- the PAM service ships with
+    // the lock screen itself.
     PamContext {
         id: pam
         property string pendingPassword: ""
 
+        config: "ryoku-lock"
+        configDirectory: Quickshell.shellDir + "/assets/pam"
+
+        // When PAM asks for a password (the pam_unix prompt), feed it the
+        // stashed password if we have one, or mark it as required so the
+        // theme's login() handler sends it on the next keypress.
         onResponseRequiredChanged: {
             if (responseRequired && pendingPassword !== "") {
+                shim.fpTyped = true;
                 respond(pendingPassword);
                 pendingPassword = "";
             }
         }
 
+        // PAM conversation completed. Success = unlock; failure = re-arm.
         onCompleted: (result) => {
             if (result === PamResult.Success) {
+                // A scan that ended without a typed key means the sensor won.
+                shim.fingerprintUnlock = (shim.fingerprintState === "scanning" && !shim.fpTyped);
+                shim.fingerprintState = "success";
                 shim.sddm.loginSucceeded();
                 Quickshell.execDetached(["loginctl", "unlock-session"]);
-                // Notify success handlers
             } else {
+                shim.fingerprintState = "fail";
+                shim.fpTyped = false;
                 shim.sddm.loginFailed();
+                // Conversation is over; re-arm so the next touch scans again.
+                rearmTimer.restart();
             }
         }
     }
 
+    // ── re-arm timer ────────────────────────────────────────────────────────
+    // After a failed scan, wait 700ms before re-arming. This prevents
+    // tight loops and gives the theme time to show "type your key".
+    Timer {
+        id: rearmTimer
+        interval: 700
+        onTriggered: {
+            if (!shim.armWhenReady || pam.active)
+                return;
+            if (shim.fingerprintReady)
+                shim.armFingerprint();
+        }
+    }
+
+    // ── fingerprint control functions ───────────────────────────────────────
+
+    // armFingerprint: starts a new PAM conversation with the grosshack
+    // service. The sensor begins scanning immediately.
+    function armFingerprint() {
+        if (!shim.fingerprintReady || pam.active)
+            return;
+        pam.user = Quickshell.env("USER") || "traveler";
+        pam.pendingPassword = "";
+        shim.fpTyped = false;
+        shim.fingerprintUnlock = false;
+        shim.fingerprintState = "scanning";
+        pam.start();
+    }
+
+    // resetAuth: aborts any active PAM conversation and resets state.
+    // Called when the lock surface is unlocked.
+    function resetAuth() {
+        shim.fingerprintUnlock = false;
+        shim.fpTyped = false;
+        pam.abort();
+        if (shim.fingerprintState !== "idle")
+            shim.fingerprintState = "idle";
+    }
+
+    // maybeArm: conditionally arms the fingerprint sensor. Called by both
+    // readiness probes when they finish; the arm only fires when ALL
+    // conditions are met (toggle on, fingers enrolled, lock secured).
+    function maybeArm() {
+        if (shim.armWhenReady && shim.fingerprintReady && !pam.active)
+            shim.armFingerprint();
+    }
+
+    // ── initialization ──────────────────────────────────────────────────────
     onThemePathChanged: loadConfig(themePath)
-    Component.onCompleted: { sessionEnumerator.running = true; hostnameProc.running = true }
+    Component.onCompleted: {
+        sessionEnumerator.running = true;
+        hostnameProc.running = true;
+        fpToggleProc.running = true;
+        fpListProc.running = true;
+    }
 }

--- a/ryoku/lockscreen/qylock/quickshell-lockscreen/shim/SddmShim.qml
+++ b/ryoku/lockscreen/qylock/quickshell-lockscreen/shim/SddmShim.qml
@@ -1,25 +1,17 @@
 // SddmShim.qml - Quickshell shim for Ryoku in-session lock
 //
-// This file replaces the default Quickshell SDDM shim to add fingerprint
-// unlock support via pam_fprintd_grosshack.so. It exposes the same API as
-// a real SDDM greeter (login, reboot, powerOff, suspend, userModel,
-// sessionModel, keyboard) so themes work unchanged, plus fingerprint state
-// properties that the theme reads to show a sensor hint.
+// Exposes the same API as a real SDDM greeter (login, reboot, powerOff,
+// suspend, userModel, sessionModel, keyboard) so themes work unchanged,
+// plus fingerprint state properties the theme reads for the sensor hint.
 //
-// How it works:
-//   1. On lock, lock_shell.qml sets armWhenReady = true
-//   2. This shim probes fprintd-list and reads ~/.config/qylock/fingerprint
-//   3. If fingerprint is enabled and fingers are enrolled, armFingerprint()
-//      starts a PAM conversation with the ryoku-lock service
-//   4. pam_fprintd_grosshack.so forks fprintd-verify at conversation start,
-//      so the sensor scans while pam_unix waits for a password
-//   5. Either success unlocks within the SAME conversation
-//   6. A failed scan triggers a 700ms re-arm timer for the next touch
-//
-// PAM flow (touch OR type):
-//   pam_fprintd_grosshack.so  ->  sensor scan  ->  success = unlock
-//   pam_unix.so                ->  password     ->  success = unlock
-//   pam_deny.so               ->  neither      ->  fail + re-arm
+// Fingerprint flow:
+//   1. lock_shell.qml sets armWhenReady = true once WlSessionLock.secure
+//   2. The shim probes fprintd-list + ~/.config/qylock/fingerprint
+//   3. Stale fprintd-verify processes are cleared, then a PAM conversation
+//      starts against the ryoku-lock service (grosshack pair)
+//   4. grosshack forks fprintd-verify at conversation start: the sensor
+//      scans while pam_unix waits for a password; first success wins
+//   5. A failed scan re-arms after 1s
 
 import QtQuick
 import Quickshell
@@ -49,20 +41,13 @@ Item {
     property bool armPending: false          // an armPrep run is in flight
     property bool fpTyped: false             // a key was fed to the conversation
 
-    // THE arm trigger. maybeArm() is also called by the readiness probes when
-    // they land, but both probes usually finish BEFORE the compositor acks the
-    // lock surface (WlSessionLock.secure). Without this watcher the race is
-    // lost every time: armWhenReady flips true after the last probe already
-    // ran, no conversation ever starts, and the theme keeps saying
-    // "touch sensor" while nothing at all is listening.
+    // arm the moment the lock secures; probes alone race and lose it.
     onArmWhenReadyChanged: {
         if (shim.armWhenReady)
             shim.maybeArm();
     }
 
-    // pre-arm cleanup: kill verifiers orphaned by earlier aborted
-    // conversations so the new scan can claim the sensor on its first cycle.
-    // Runs in milliseconds; the settle beat lets fprintd release the device.
+    // orphaned verifiers hold the sensor claim; clear them before arming.
     Process {
         id: armPrepProc
         command: ["bash", "-c", "pkill -u \"$USER\" -x fprintd-verify 2>/dev/null; sleep 0.2"]
@@ -405,10 +390,7 @@ Item {
         }
     }
 
-    // ── re-arm timer ────────────────────────────────────────────────────────
-    // After a failed scan, wait a moment before re-arming: the aborted
-    // conversation's fprintd-verify needs to release the sensor claim, and
-    // the theme needs a beat to show "type your key".
+    // settle before rescanning so the old verifier releases the claim.
     Timer {
         id: rearmTimer
         interval: 1000
@@ -422,12 +404,6 @@ Item {
 
     // ── fingerprint control functions ───────────────────────────────────────
 
-    // armFingerprint: clears any stale fprintd-verify first, then starts a
-    // new PAM conversation with the grosshack service. Killing strays matters:
-    // an aborted conversation leaves its forked verifier alive, the orphan
-    // keeps the sensor claim, and the next scan silently cannot start -- the
-    // user sees "touch the sensor", touches, nothing happens, and only a
-    // burned password cycle (fail -> re-arm -> fresh verifier) revives it.
     function armFingerprint() {
         if (!shim.fingerprintReady || pam.active || shim.armPending)
             return;
@@ -461,11 +437,7 @@ Item {
             shim.fingerprintState = "idle";
     }
 
-    // maybeArm: conditionally arms the fingerprint sensor. Called by both
-    // readiness probes when they finish AND whenever the secured flag flips.
     function maybeArm() {
-        console.log("[fp] maybeArm: secure=" + shim.armWhenReady,
-            "ready=" + shim.fingerprintReady, "active=" + pam.active);
         if (shim.armWhenReady && shim.fingerprintReady && !pam.active)
             shim.armFingerprint();
     }

--- a/ryoku/lockscreen/qylock/quickshell-lockscreen/shim/SddmShim.qml
+++ b/ryoku/lockscreen/qylock/quickshell-lockscreen/shim/SddmShim.qml
@@ -46,7 +46,33 @@ Item {
     property string fingerprintState: "idle" // idle | scanning | success | fail
     property bool fingerprintUnlock: false   // true if sensor won (not typed)
     property bool armWhenReady: false        // lock surface is secured, arm now
+    property bool armPending: false          // an armPrep run is in flight
     property bool fpTyped: false             // a key was fed to the conversation
+
+    // THE arm trigger. maybeArm() is also called by the readiness probes when
+    // they land, but both probes usually finish BEFORE the compositor acks the
+    // lock surface (WlSessionLock.secure). Without this watcher the race is
+    // lost every time: armWhenReady flips true after the last probe already
+    // ran, no conversation ever starts, and the theme keeps saying
+    // "touch sensor" while nothing at all is listening.
+    onArmWhenReadyChanged: {
+        if (shim.armWhenReady)
+            shim.maybeArm();
+    }
+
+    // pre-arm cleanup: kill verifiers orphaned by earlier aborted
+    // conversations so the new scan can claim the sensor on its first cycle.
+    // Runs in milliseconds; the settle beat lets fprintd release the device.
+    Process {
+        id: armPrepProc
+        command: ["bash", "-c", "pkill -u \"$USER\" -x fprintd-verify 2>/dev/null; sleep 0.2"]
+        onExited: () => {
+            if (!shim.armPending)
+                return;
+            shim.armPending = false;
+            shim.armFingerprintNow();
+        }
+    }
 
     // ── theme config loader ─────────────────────────────────────────────────
     // Parses theme.conf (key=value format) from the theme directory.
@@ -278,7 +304,9 @@ Item {
     }
 
     // Probe enrolled fingers; the lock only offers the sensor when this user
-    // actually has one stored.
+    // actually has one stored. fprintd itself is D-Bus activated, so right at
+    // lock time the daemon (and the device) may not be up yet -- a failed or
+       // finger-less probe is retried a few times while the lock is held.
     Process {
         id: fpListProc
         command: ["fprintd-list", Quickshell.env("USER") || "traveler"]
@@ -301,6 +329,21 @@ Item {
                 shim.fpHasFingers = false;
                 shim.maybeArm();
             }
+            listRetry.restart();
+        }
+    }
+
+    // bounded re-probe: three tries, two and a half seconds apart, only while
+    // the lock is actually held and we still have no fingers on record.
+    Timer {
+        id: listRetry
+        interval: 2500
+        property int tries: 0
+        onTriggered: {
+            if (shim.fpHasFingers || !shim.armWhenReady || tries >= 3)
+                return;
+            tries++;
+            fpListProc.running = true;
         }
     }
 
@@ -349,14 +392,26 @@ Item {
                 rearmTimer.restart();
             }
         }
+
+        // A conversation can also die without completing -- config missing,
+        // internal PAM error, subprocess killed. Left unhandled, the theme
+        // would keep claiming the sensor is listening while no scan exists.
+        onError: (error) => {
+            if (!shim.armWhenReady)
+                return;
+            shim.fingerprintState = "fail";
+            shim.fpTyped = false;
+            rearmTimer.restart();
+        }
     }
 
     // ── re-arm timer ────────────────────────────────────────────────────────
-    // After a failed scan, wait 700ms before re-arming. This prevents
-    // tight loops and gives the theme time to show "type your key".
+    // After a failed scan, wait a moment before re-arming: the aborted
+    // conversation's fprintd-verify needs to release the sensor claim, and
+    // the theme needs a beat to show "type your key".
     Timer {
         id: rearmTimer
-        interval: 700
+        interval: 1000
         onTriggered: {
             if (!shim.armWhenReady || pam.active)
                 return;
@@ -367,9 +422,20 @@ Item {
 
     // ── fingerprint control functions ───────────────────────────────────────
 
-    // armFingerprint: starts a new PAM conversation with the grosshack
-    // service. The sensor begins scanning immediately.
+    // armFingerprint: clears any stale fprintd-verify first, then starts a
+    // new PAM conversation with the grosshack service. Killing strays matters:
+    // an aborted conversation leaves its forked verifier alive, the orphan
+    // keeps the sensor claim, and the next scan silently cannot start -- the
+    // user sees "touch the sensor", touches, nothing happens, and only a
+    // burned password cycle (fail -> re-arm -> fresh verifier) revives it.
     function armFingerprint() {
+        if (!shim.fingerprintReady || pam.active || shim.armPending)
+            return;
+        shim.armPending = true;
+        armPrepProc.running = true;
+    }
+
+    function armFingerprintNow() {
         if (!shim.fingerprintReady || pam.active)
             return;
         pam.user = Quickshell.env("USER") || "traveler";
@@ -377,7 +443,12 @@ Item {
         shim.fpTyped = false;
         shim.fingerprintUnlock = false;
         shim.fingerprintState = "scanning";
-        pam.start();
+        // start() returns false when the config dir/file or user cannot be
+        // resolved; surface that instead of failing silently.
+        var started = pam.start();
+        if (!started)
+            console.warn("[fp] pam.start() failed: config=", pam.config,
+                "dir=", pam.configDirectory, "user=", pam.user);
     }
 
     // resetAuth: aborts any active PAM conversation and resets state.
@@ -391,9 +462,10 @@ Item {
     }
 
     // maybeArm: conditionally arms the fingerprint sensor. Called by both
-    // readiness probes when they finish; the arm only fires when ALL
-    // conditions are met (toggle on, fingers enrolled, lock secured).
+    // readiness probes when they finish AND whenever the secured flag flips.
     function maybeArm() {
+        console.log("[fp] maybeArm: secure=" + shim.armWhenReady,
+            "ready=" + shim.fingerprintReady, "active=" + pam.active);
         if (shim.armWhenReady && shim.fingerprintReady && !pam.active)
             shim.armFingerprint();
     }

--- a/ryoku/lockscreen/qylock/themes/clockwork/orbital/Main.qml
+++ b/ryoku/lockscreen/qylock/themes/clockwork/orbital/Main.qml
@@ -19,6 +19,20 @@ Rectangle {
 
     property bool isQuickshell: typeof sddm === "undefined" || sddm.hostName === undefined
 
+    // ── fingerprint sensor hint ─────────────────────────────────────────────
+    // Driven by the lock shim's carry-over props (fingerprintHint,
+    // fingerprintReady, fingerprintState). These are undefined under a real
+    // SDDM greeter, so every gate evaluates false and the hint is invisible
+    // there. Under the lock screen shim, they drive the sensor hint UI.
+    readonly property bool fpVisible: (typeof sddm !== "undefined") && sddm.fingerprintHint === true && sddm.fingerprintReady === true
+    readonly property var fpState: typeof sddm !== "undefined" ? (sddm.fingerprintState || "idle") : "idle"
+    readonly property string fpHintText: {
+        if (root.fpState === "success") return "ACCESS GRANTED ✦"
+        if (root.fpState === "fail")    return "SCAN DENIED ✦ TYPE YOUR KEY"
+        if (root.fpState === "scanning") return "SENSOR ACTIVE ✦ TOUCH OR TYPE"
+        return "TOUCH SENSOR ✦ TO UNLOCK"
+    }
+
     // Theme Config
     readonly property string themeMode: config.themeMode || "dark"
     readonly property bool enableWindup: config.enableWindup !== "false" && config.enableWindup !== false
@@ -85,6 +99,14 @@ Rectangle {
         onFinished: root.doLogin()
         NumberAnimation { target: root; property: "boomScale"; to: 35.0; duration: 150; easing.type: Easing.InQuad }
         NumberAnimation { target: root; property: "boomOpacity"; to: 1.0; duration: 120; easing.type: Easing.InQuad }
+    }
+
+    // Fingerprint unlock flourish: the windup's reveal without the windup, run
+    // only on a genuine sensor win (never triggers a second authentication).
+    ParallelAnimation {
+        id: boomReveal
+        NumberAnimation { target: root; property: "boomScale"; to: 35.0; duration: 190; easing.type: Easing.InQuad }
+        NumberAnimation { target: root; property: "boomOpacity"; to: 1.0; duration: 130; easing.type: Easing.InQuad }
     }
 
     readonly property real smoothSecAngle: -((localTimeMS % 60000) / 60000.0) * 360.0 - windupOffset * 10.0
@@ -258,6 +280,38 @@ Rectangle {
                 Text { text: "✦"; anchors.left: userNameDisp.right; anchors.leftMargin: 8 * s; anchors.verticalCenter: userNameDisp.verticalCenter; color: root.mainText; opacity: (uMa.containsMouse || root.userMenuOpen) ? 1.0 : 0; font.pixelSize: 12 * s; Behavior on opacity { NumberAnimation { duration: 200 } } }
                 MouseArea { id: uMa; anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor; onClicked: { root.userMenuOpen = !root.userMenuOpen } }
             }
+            // ── fingerprint sensor hint ─────────────────────────────────────
+            // Sits between the user name and the password field so the eye
+            // naturally hits it before typing. Uses mainText for full brightness
+            // while scanning (not dim subColor). A pulse animation makes it
+            // clear the sensor is active.
+            Text {
+                id: fpHint
+                width: parent.width
+                height: root.fpVisible ? 16 * s : 0
+                visible: root.fpVisible
+                horizontalAlignment: Text.AlignRight
+                verticalAlignment: Text.AlignVCenter
+                text: root.fpHintText
+                color: root.fpState === "success" ? root.mainText
+                    : (root.fpState === "fail" ? "#ff4444"
+                    : (root.fpState === "scanning" ? root.mainText : root.dimText))
+                font.family: outfitFont.name
+                font.pixelSize: 9 * s
+                font.letterSpacing: 2 * s
+                opacity: root.fpState === "scanning" ? fpPulse.value : 1.0
+                Behavior on color { ColorAnimation { duration: 200 } }
+                Behavior on height { NumberAnimation { duration: 200; easing.type: Easing.OutCubic } }
+            }
+            // Gentle opacity pulse while the sensor listens.
+            SequentialAnimation {
+                id: fpPulse
+                loops: Animation.Infinite
+                running: root.fpVisible && root.fpState === "scanning"
+                NumberAnimation { target: fpPulseVal; property: "value"; from: 1.0; to: 0.45; duration: 600; easing.type: Easing.InOutSine }
+                NumberAnimation { target: fpPulseVal; property: "value"; from: 0.45; to: 1.0; duration: 600; easing.type: Easing.InOutSine }
+            }
+            Item { id: fpPulseVal; property real value: 1.0 }
             Item {
                 width: parent.width; height: 30 * s
                 TextInput {
@@ -294,12 +348,29 @@ Rectangle {
             doLogin()
         }
     }
-    function doLogin() { var uname = (userHelper.currentItem && userHelper.currentItem.uLogin) ? userHelper.currentItem.uLogin : (typeof userModel !== "undefined" ? userModel.lastUser : "user"); if (typeof sddm !== "undefined") sddm.login(uname, passInput.text, root.sessionIndex) }
+    // ── race condition guard ────────────────────────────────────────────────
+    // _unlocked prevents boomSequence.onFinished: doLogin() from firing a
+    // second PAM auth if the fingerprint wins mid-windup (after
+    // boomTriggerTimer at 1450ms). boomSequence.stop() kills the animation.
+    property bool _unlocked: false
+    function doLogin() { if (_unlocked) return; _unlocked = true; var uname = (userHelper.currentItem && userHelper.currentItem.uLogin) ? userHelper.currentItem.uLogin : (typeof userModel !== "undefined" ? userModel.lastUser : "user"); if (typeof sddm !== "undefined") sddm.login(uname, passInput.text, root.sessionIndex) }
     function capitalizeFirst(str) { if (!str) return ""; return str.charAt(0).toUpperCase() + str.slice(1) }
+    // ── login event handlers ────────────────────────────────────────────────
     Connections {
         target: typeof sddm !== "undefined" ? sddm : null
-        function onLoginSucceeded() { }
-        function onLoginFailed() { isWindup = false; windupAnim.stop(); boomTriggerTimer.stop(); boomSequence.stop(); root.windupOffset = 0; root.boomScale = 1.0; root.boomOpacity = 0.0; root.sparkIntensity = 0; errText.text = "ACCESS DENIED"; passInput.text = ""; passInput.forceActiveFocus(); shake.start() }
+        function onLoginSucceeded() {
+            if (typeof sddm !== "undefined" && sddm.fingerprintUnlock === true) {
+                // Sensor win: skip the windup, play the reveal flourish, no
+                // second authentication. The _unlocked guard prevents
+                // boomSequence.onFinished from calling doLogin() again.
+                _unlocked = true
+                windupAnim.stop()
+                boomTriggerTimer.stop()
+                boomSequence.stop()
+                boomReveal.start()
+            }
+        }
+        function onLoginFailed() { _unlocked = false; isWindup = false; windupAnim.stop(); boomTriggerTimer.stop(); boomSequence.stop(); root.windupOffset = 0; root.boomScale = 1.0; root.boomOpacity = 0.0; root.sparkIntensity = 0; errText.text = "ACCESS DENIED"; passInput.text = ""; passInput.forceActiveFocus(); shake.start() }
     }
     SequentialAnimation {
         id: shake


### PR DESCRIPTION
Supersedes #48 (that branch grew through three debugging rounds and 2k+ lines of churn; this is the same work, cleaned, documented and complete).

## What you get

Touch-to-unlock via `pam_fprintd_grosshack.so` in **three places**, all managed from Settings → Lockscreen → Fingerprint:

| Surface | Mechanism |
|---|---|
| Lock screen (`Super+L`) | self-contained `assets/pam/ryoku-lock` service loaded via `PamContext.configDirectory` — no `/etc/pam.d` edit |
| Sudo | toggle: injects/removes one grosshack line at the top of `/etc/pam.d/sudo` |
| SDDM greeter | toggle: same for `/etc/pam.d/sddm` |

The toggles run the root half through `pkexec`, back each file up to `<svc>.ryoku-fp-bak`, and removal deletes only the injected line. Status is grep-read live so a pre-existing line shows as already-on.

## Two bugs that made earlier iterations dead on arrival — both fixed

1. **Arm race**: readiness probes finish *before* `WlSessionLock.secure` flips, so arming never fired — the hint said "touch sensor" while no PAM conversation existed. Fixed by arming on `onArmWhenReadyChanged`.
2. **Stale verifiers**: aborted conversations orphaned their forked `fprintd-verify`; the orphan kept the sensor claim, so every later scan silently failed until a wasted wrong-password cycle re-armed it. Every arm now runs `pkill -u $USER -x fprintd-verify` first.

Plus: `onError` handling (dead conversations can't fake "listening"), bounded finger-probe retries (fprintd is D-Bus activated), `pam.start()` failure surfaced.

## Settings UI

- enroll modal: paper progress ring with real stage counts (`num-enroll-stages` off D-Bus, passes parsed live from stdout+stderr with per-stream offsets), human retry guidance ("too short", "center your finger", ...), naming step in the footer
- verify: match/no-match plate, auto-close on success
- two-step destructive confirms; labels stay in sync on delete
- settings card full-width (symmetric with gallery), two columns: controls left, prints right
- theme untouched

## Requirements / Dependencies

- `fprintd`, `pam_fprintd_grosshack.so`, quickshell ≥ 0.3 with `Quickshell.Services.Pam`
- `busctl` (enroll progress), `pkexec`/polkit (sudo/sddm toggles) — stock Arch
- libfprint-supported sensor + ≥ 1 enrolled finger

## Docs & Testing

- [`README`](../blob/fingerprint-unlock-v2/ryoku/lockscreen/fingerprint-unlock/README.md) — scope, requirements table, install
- [`architecture`](../blob/fingerprint-unlock-v2/ryoku/lockscreen/fingerprint-unlock/docs/architecture.md) — PAM flow, arm lifecycle, both race fixes
- [`testing`](../blob/fingerprint-unlock-v2/ryoku/lockscreen/fingerprint-unlock/docs/testing.md) — tester checklist (enrollment, lock/unlock matrix, toggles, regressions)
- [`CHANGELOG`](../blob/fingerprint-unlock-v2/ryoku/lockscreen/fingerprint-unlock/CHANGELOG.md)

Verified headless: secure → arm → grosshack relays "Enter Password or Place finger" in one conversation; clean abort leaves no strays. Comment trimming pass keeps the reviewable diff tight.