### PR TITLE
fix(matugen): avoid breaking Steam first-launch bootstrap

### DIFF
--- a/ryoku/hub/backend/matugen.go
+++ b/ryoku/hub/backend/matugen.go
@@ -170,6 +170,16 @@ func matugenConfigPath() string {
 	return filepath.Join(base, "ryoku", "matugen.json")
 }
 
+func steamThemeReady() bool {
+	home := os.Getenv("HOME")
+	if home == "" {
+		return false
+	}
+
+	info, err := os.Stat(filepath.Join(home, ".steam", "steam", "steamui"))
+	return err == nil && info.IsDir()
+}
+
 func loadMatugenConfig() matugenConfig {
 	cfg := defaultMatugenConfig()
 	b, err := os.ReadFile(matugenConfigPath())
@@ -245,7 +255,6 @@ func renderActiveTemplates(cfg matugenConfig, pal map[string]string) {
 		filepath.Join(configHome(), "zed", "themes"),
 		filepath.Join(configHome(), "heroic", "store", "styles"),
 		filepath.Join(dataHome, "TelegramDesktop", "tdata"),
-		filepath.Join(home, ".steam", "steam", "steamui", "skins", "Material-Theme", "css", "main", "colors"),
 		filepath.Join(configHome(), "cava"),
 		filepath.Join(configHome(), "fish", "conf.d"),
 		filepath.Join(configHome(), "yazi"),
@@ -255,6 +264,9 @@ func renderActiveTemplates(cfg matugenConfig, pal map[string]string) {
 	}
 	for _, d := range targetDirs {
 		_ = os.MkdirAll(d, 0o755)
+	}
+	if steamThemeReady() {
+		_ = os.MkdirAll(filepath.Join(home, ".steam", "steam", "steamui", "skins", "Material-Theme", "css", "main", "colors"), 0o755)
 	}
 
 	carrierPath := filepath.Join(cacheDir, "matugen-carrier.json")
@@ -299,6 +311,9 @@ func renderActiveTemplates(cfg matugenConfig, pal map[string]string) {
 					groupKey = "qt5"
 				case "vesktop", "equibop":
 					groupKey = "discord"
+				}
+				if appName == "steam" && !steamThemeReady() {
+					continue
 				}
 				if enabled, ok := cfg.Templates[groupKey]; !ok || enabled {
 					activeSections = append(activeSections, secStr)

--- a/ryoku/shell/ipc/matugen.go
+++ b/ryoku/shell/ipc/matugen.go
@@ -1016,6 +1016,9 @@ func matugenRenderTemplates(shell map[string]string, k matugenKnobs) {
 	// Absent-means-off would have kept every app added from here on dark for
 	// everyone who had ever opened the appearance page.
 	enabled := func(group string) bool {
+		if group == "steam" && !steamThemeReady() {
+			return false
+		}
 		if v, ok := k.Templates[group]; ok {
 			return v
 		}
@@ -1238,6 +1241,7 @@ func matugenEnsureDirs() {
 	cfg := matugenConfigHome()
 	cache := matugenCacheHome()
 	data := matugenDataHome()
+	home := os.Getenv("HOME")
 	for _, d := range []string{
 		filepath.Join(cache, "ryoku"),
 		filepath.Join(cache, "matugen"),
@@ -1263,10 +1267,22 @@ func matugenEnsureDirs() {
 		filepath.Join(cfg, "alacritty"),
 		filepath.Join(cfg, "tmux"),
 		filepath.Join(data, "TelegramDesktop", "tdata"),
-		filepath.Join(os.Getenv("HOME"), ".steam", "steam", "steamui", "skins", "Material-Theme", "css", "main", "colors"),
 	} {
 		_ = os.MkdirAll(d, 0o755)
 	}
+	if steamThemeReady() {
+		_ = os.MkdirAll(filepath.Join(home, ".steam", "steam", "steamui", "skins", "Material-Theme", "css", "main", "colors"), 0o755)
+	}
+}
+
+func steamThemeReady() bool {
+	home := os.Getenv("HOME")
+	if home == "" {
+		return false
+	}
+
+	info, err := os.Stat(filepath.Join(home, ".steam", "steam", "steamui"))
+	return err == nil && info.IsDir()
 }
 
 // writeJSONFile writes v as indented JSON atomically (temp file then rename), so


### PR DESCRIPTION
Ryoku's Matugen renderers previously pre-created the Steam Material theme output path under ~/.steam/steam/steamui. On fresh systems where Steam had not initialized yet, this could create ~/.steam/steam as a real directory and prevent Steam from creating its expected bootstrap layout.

This gates Steam theme directory creation and Steam template rendering on the existence of ~/.steam/steam/steamui, so Steam theming is deferred until Steam has initialized.

Tests:
- go test ./... in ryoku/hub/backend
- go test ./... in ryoku/shell/ipc