### PR TITLE
fix: idle GPU pinned at 50-70% - ungated clock colon-blink animation

### DIFF
--- a/ryoku/shell/quickshell/shell/modules/desktop/clock/ClockDigital.qml
+++ b/ryoku/shell/quickshell/shell/modules/desktop/clock/ClockDigital.qml
@@ -48,11 +48,6 @@ Item {
                 font.family: Theme.mono
                 font.pixelSize: face.px
                 font.weight: Font.Bold
-                SequentialAnimation on opacity {
-                    loops: Animation.Infinite
-                    NumberAnimation { from: 1; to: 0.3; duration: 620; easing.type: Easing.InOutSine }
-                    NumberAnimation { from: 0.3; to: 1; duration: 620; easing.type: Easing.InOutSine }
-                }
             }
             Text {
                 text: face.t.mm

--- a/ryoku/shell/quickshell/shell/modules/wallpaper/Backdrop.qml
+++ b/ryoku/shell/quickshell/shell/modules/wallpaper/Backdrop.qml
@@ -173,8 +173,12 @@ Item {
         cache: false
         asynchronous: true
         fillMode: view.fillModeFor(imgA)
-        onStatusChanged: if (status === Image.Ready && source == view.url && !view.aFront)
-            view.startReveal()
+        onStatusChanged: {
+            if (status === Image.Ready)
+                srcA.scheduleUpdate();
+            if (status === Image.Ready && source == view.url && !view.aFront)
+                view.startReveal();
+        }
     }
     Image {
         id: imgB
@@ -182,21 +186,27 @@ Item {
         cache: false
         asynchronous: true
         fillMode: view.fillModeFor(imgB)
-        onStatusChanged: if (status === Image.Ready && source == view.url && view.aFront)
-            view.startReveal()
+        onStatusChanged: {
+            if (status === Image.Ready)
+                srcB.scheduleUpdate();
+            if (status === Image.Ready && source == view.url && view.aFront)
+                view.startReveal();
+        }
     }
 
+    // live:false + an explicit scheduleUpdate() on load: re-capture only when the
+    // image content actually changes, not every frame forever on a static wallpaper.
     ShaderEffectSource {
         id: srcA
         sourceItem: imgA
         hideSource: true
-        live: true
+        live: false
     }
     ShaderEffectSource {
         id: srcB
         sourceItem: imgB
         hideSource: true
-        live: true
+        live: false
     }
 
     // The reveal: mix(oldTex, newTex, mask) over the shared duration. oldTex is the


### PR DESCRIPTION
Follow-up to #60 with a confirmed root cause and a fix.

## Root cause

`ClockDigital.qml`'s colon glyph had this, with no `running:` guard:

```qml
SequentialAnimation on opacity {
    loops: Animation.Infinite
    NumberAnimation { from: 1; to: 0.3; duration: 620; easing.type: Easing.InOutSine }
    NumberAnimation { from: 0.3; to: 1; duration: 620; easing.type: Easing.InOutSine }
}
```

It's the only `Animation.Infinite` in the codebase without a `running` condition tied to something real (`BatteryWidget`'s pulse, `MprisWidget`'s EQ bars, and the qsbar drift shader all gate on something). Because it lives inside the full-screen `ryoku-widgets` layer-shell surface, Hyprland ends up recompositing that whole transparent layer every cycle, forever - on every power profile, since this was never wired into the `Perf` tier system at all.

Disabling the widget via `clockEnabled: false` doesn't help on its own: `visible: false` on the wrapping `WidgetSlot` hides it from paint, but doesn't stop a bare `Animation on <property>` from continuing to run underneath. That's why the cost persists even for users who've turned the clock off.

## How this was isolated

Live A/B testing on real hardware (Intel Iris Xe), using both `nvtop` GPU% and the `i915` interrupt rate in `/proc/interrupts` as a cleaner signal:

- Bar-gap drift shader (the fix from 5c1f58c) - not loaded by default (`barAnim: 0`), and unrelated code path regardless
- blur / shadows / reduce-motion / full Power Saver tier - no measurable change
- Entire `qsbar` bar style swapped for `sumi` - no change
- Stripped `Desktop.qml` down to a bare empty `PanelWindow` - GPU dropped to ~10%
- Added widgets back one at a time: calendar (even glass-style) alone - stayed ~11%. Added the clock - jumped to 53-57%.
- Removed just the blink animation, everything else restored to normal - **GPU dropped to 0-16%, averaging ~8%**

| | GPU util | `i915` IRQ rate |
|---|---|---|
| Before | 55-70% | ~300-340/sec |
| After | 0-16%, avg ~8% | ~119/sec |

## Why removed outright, not gated behind a profile check

Gating this behind `!Perf.reduceMotion` or Performance-tier-only (matching how the bar-gap drift's `ambientMotion` works) would leave the bug fully present on Performance profile by default - which is the tier both #60's original report and this one were measured under. The fix wouldn't actually fix the reported problem for most users. A few hundred ms of colon fade isn't worth a 50+ point GPU cost, so this removes it rather than making it conditional.

**This does not touch `StreamShader`/`ParticleStream`/`ReactorLayer`** (the bar-gap drift "ambient motion" system) in any way, so that Performance-tier visual candy is unaffected - confirmed by grep, zero overlap in files or symbols touched.

## Second, related bug found and fixed along the way

`Backdrop.qml`'s `srcA`/`srcB` `ShaderEffectSource` had `live: true` unconditionally - re-capturing the wallpaper texture every frame forever, even on a fully static image. Changed to `live: false` paired with an explicit `scheduleUpdate()` call the moment each image actually finishes loading. (Note: `live: false` alone, without the paired `scheduleUpdate()`, leaves the captured texture permanently black, since the source images load asynchronously and start empty - caught this the hard way during testing, calling it out in case it's useful for anyone touching this file in the future.)

## Testing

Both changes tested live via `ryoku deploy`-style materialized config + `systemctl --user restart ryoku-shell` across multiple clean restarts, confirmed via `nvtop`, `/proc/interrupts`, and a screenshot to confirm the wallpaper renders correctly after the second fix.

Happy to adjust based on maintainer preference (e.g. if you'd rather see the blink preserved via some other mechanism that doesn't force full-layer recomposition, though that's a bigger structural change than this PR).