### PR TITLE
[ryoku] hub: add press/release trigger toggle for custom keybinds

### DIFF
--- a/ryoku/hub/backend/hypr.go
+++ b/ryoku/hub/backend/hypr.go
@@ -193,6 +193,7 @@ type Keybind struct {
 	Keys   string `json:"keys"`
 	Action string `json:"action"`
 	Value  string `json:"value"`
+	Release bool   `json:"release,omitempty"`
 }
 
 // AnimCurve = a user bezier. P0/P3 fixed at (0,0) and (1,1); only the two
@@ -1565,6 +1566,9 @@ func genKeybind(k Keybind) string {
 		dsp = "hl.dsp.window.float({ action = \"toggle\" })"
 	default:
 		return ""
+	}
+	if k.Release {
+		return fmt.Sprintf("hl.bind(%s, %s, { release = true })\n", luaStr(k.Keys), dsp)
 	}
 	return fmt.Sprintf("hl.bind(%s, %s)\n", luaStr(k.Keys), dsp)
 }

--- a/ryoku/hub/quickshell/pages/KeybindsPage.qml
+++ b/ryoku/hub/quickshell/pages/KeybindsPage.qml
@@ -247,7 +247,7 @@ Item {
         if (!pg.hubReady)
             return;
         var a = (pg.hub.hyprVal("keybinds") || []).slice();
-        a.push({ "keys": "", "action": "exec", "value": "" });
+        a.push({ "keys": "", "action": "exec", "value": "", "release": false });
         pg.hub.hyprEdit("keybinds", a);
     }
     function removeRow(i) {
@@ -988,7 +988,7 @@ Item {
                             id: rowRect
                             required property int index
                             required property var modelData
-
+                            readonly property bool isRelease: rowRect.modelData.release === true
                             readonly property int lineH: 30
                             readonly property real gap: Tokens.s2
                             readonly property real removeW: 26
@@ -1035,7 +1035,36 @@ Item {
                                             pg.patch(rowRect.index, "keys", v);
                                     }
                                 }
+                                Rectangle {
+                                    id: releaseToggle
+                                    anchors.right: removeBtn.left
+                                    anchors.rightMargin: rowRect.gap
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    implicitHeight: 24
+                                    implicitWidth: relText.implicitWidth + 12
+                                    radius: Tokens.radius
+                                    color: rowRect.isRelease ? Tokens.ink : "transparent"
+                                    border.width: Tokens.border
+                                    border.color: rowRect.isRelease ? Tokens.ink : Tokens.line
 
+                                    Text {
+                                        id: relText
+                                        anchors.centerIn: parent
+                                        text: rowRect.isRelease ? "RELEASE" : "PRESS"
+                                        color: rowRect.isRelease ? Tokens.paper : Tokens.inkFaint
+                                        font.family: Tokens.mono
+                                        font.pixelSize: Tokens.fMicro
+                                        font.weight: Font.Medium
+                                    }
+
+                                    HoverHandler { id: relHov; cursorShape: Qt.PointingHandCursor }
+                                    TapHandler {
+                                        onTapped: {
+                                            if (pg.hubReady)
+                                                pg.patch(rowRect.index, "release", !rowRect.isRelease);
+                                        }
+                                    }
+                                }
                                 // record: capture the combo by pressing it. Safe
                                 // because startRecord enters the record submap
                                 // first, so the live chord reaches the field, not
@@ -1064,7 +1093,7 @@ Item {
                                 // bar fills whatever is left when it is hidden.
                                 Item {
                                     id: cmdBox
-                                    anchors.right: removeBtn.left
+                                    anchors.right: releaseToggle.left
                                     anchors.rightMargin: rowRect.gap
                                     anchors.verticalCenter: parent.verticalCenter
                                     height: rowRect.lineH


### PR DESCRIPTION
## What changed

Adds a trigger mode toggle (PRESS / RELEASE) to custom keybinds in Ryoku Hub under APPS & KEYS -> Keybinds -> CUSTOM. 

- Updates the hub UI to allow toggling between press and release triggers for custom shortcuts.
- Updates the go backend serializer (`genKeybind` in `hypr.go`) to emit `{ release = true }` in `settings.lua` when release mode is selected.

## Area

ryoku

## How it was tested

- Built `ryoku-hub` backend and deployed the shell via `deploy.sh` in a clean arch linux VM using ryoport.
- Opened ryoku-hub (Super + ,), navigated to Keybinds -> CUSTOM, and added custom shortcuts with the RELEASE toggle enabled.
- Verified that saving writes `hl.bind(..., { release = true })` into `~/.config/hypr/settings.lua`.
- Tested the shortcuts live in Hyprland to verify the command executes on key release rather than key press.

<img width="1002" height="193" alt="image" src="https://github.com/user-attachments/assets/2ca385c2-1d50-40f6-893d-f3c0f1c99332" />


## Checklist

- [x] One logical change, with a clear `[area] scope: summary` commit subject.
- [x] Matching `CHANGELOG.md` updated in the area I touched.
- [x] The git hooks pass locally; I did not use `--no-verify`.
- [x] Lua parses (`luac -p`), shell scripts pass `bash -n`, and QML passes `qmllint` where applicable.
- [x] No duplicated config, no dead code, no commented-out code, no em-dash.
- [x] Docs updated if behavior or layout changed.