### PR TITLE
[ryoku] Keybinds: Add key binding to pin floating windows

### DIFF
--- a/ryoku/hyprland/modules/binds.lua
+++ b/ryoku/hyprland/modules/binds.lua
@@ -14,6 +14,7 @@ local function K(k) return rebinds[k] or k end
 -- Windows
 hl.bind(K(mod .. " + Q"),         hl.dsp.window.close())                           -- close active window
 hl.bind(K(mod .. " + F"),         hl.dsp.window.fullscreen())                      -- fullscreen
+hl.bind(K(mod .. " + SHIFT + P"), hl.dsp.window.pin())                             -- pin a floating window
 hl.bind(K(mod .. " + A"),         function() hl.dispatch(hl.dsp.window.float({ action = "toggle" })); hl.dispatch(hl.dsp.window.resize({ x = 1000, y = 660, exact = true })); hl.dispatch(hl.dsp.window.center()) end) -- float at 1000x660, centred (press again to tile back)
 hl.bind(K(mod .. " + R"),         function() hl.dispatch(hl.dsp.submap("resize")); hl.dispatch(hl.dsp.exec_cmd("hyprctl notify -1 2200 0 'Resize mode: arrows or hjkl resize, Esc exits'")) end) -- resize mode (arrows/hjkl resize, Esc exits)
 hl.bind(K(mod .. " + P"),         hl.dsp.exec_cmd("ryoku-monitor toggle"))         -- mirror <-> extend displays


### PR DESCRIPTION
<!-- Keep one logical change per pull request. See CONTRIBUTING.md. -->

## What changed

Added a SUPER + SHIFT + P keybind to pin the focused window in Hyprland.

## Area

ryoku

## How it was tested

Tested locally in Hyprland by pressing SUPER + SHIFT + P with a floating window focused. The window is pinned successfully.

## Checklist

- [x] One logical change, with a clear `[area] scope: summary` commit subject.
- [ ] Matching `CHANGELOG.md` updated in the area I touched.
- [x] The git hooks pass locally; I did not use `--no-verify`.
- [x] Lua parses (`luac -p`), shell scripts pass `bash -n`, and QML passes
      `qmllint` where applicable.
- [x] No duplicated config, no dead code, no commented-out code, no em-dash.
- [ ] Docs updated if behavior or layout changed.
