### PR TITLE
Fix overview workspace creation on secondary outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ for finer detail.
   example.
 
 ### Fixed
+- The overview's new-workspace controls now allocate workspace ids globally, so
+  clicking `+` or `NEW` on a secondary monitor creates the workspace on that
+  monitor instead of jumping to an existing workspace on another output.
 - Limine now shows the generated boot menu: the branded config moved from
   `/boot/limine/limine.conf` (which Limine scans first, shadowing everything
   `limine-entry-tool` generates into `/boot/limine.conf`: the UKI tree and the

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -69,6 +69,12 @@ Two ways to override, neither of which blocks a fix:
   forks are the files you see in the overlay; `ryoku reset <path>` takes the new
   base.
 
+  That includes temporary QML workarounds. If you copied
+  `quickshell/shell/modules/overview/Overview.qml` or `WorkspaceCell.qml` into
+  `user_edits` to fix monitor-local workspace creation, remove that fork with
+  `ryoku reset <path>` after the packaged fix ships so the global workspace-id
+  allocator in the base file can take over.
+
 Ryoku Settings writes its generated `hypr/settings.lua` and `hypr/rebinds.lua`
 into the overlay (authored under `user_edits`, reflected live). Its other state
 (bar, colours, launcher, device lighting) it keeps under `~/.config/ryoku`,

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -69,12 +69,6 @@ Two ways to override, neither of which blocks a fix:
   forks are the files you see in the overlay; `ryoku reset <path>` takes the new
   base.
 
-  That includes temporary QML workarounds. If you copied
-  `quickshell/shell/modules/overview/Overview.qml` or `WorkspaceCell.qml` into
-  `user_edits` to fix monitor-local workspace creation, remove that fork with
-  `ryoku reset <path>` after the packaged fix ships so the global workspace-id
-  allocator in the base file can take over.
-
 Ryoku Settings writes its generated `hypr/settings.lua` and `hypr/rebinds.lua`
 into the overlay (authored under `user_edits`, reflected live). Its other state
 (bar, colours, launcher, device lighting) it keeps under `~/.config/ryoku`,

--- a/ryoku/shell/quickshell/shell/modules/overview/Overview.qml
+++ b/ryoku/shell/quickshell/shell/modules/overview/Overview.qml
@@ -82,13 +82,30 @@ Item {
         out.sort(function (a, b) { return a - b; });
         return out;
     }
+    readonly property var globalWsIds: {
+        var out = [];
+        var all = Hyprland.workspaces.values;
+        for (var i = 0; i < all.length; i++) {
+            var w = all[i];
+            if (w && w.id > 0)
+                out.push(w.id);
+        }
+        out.sort(function (a, b) { return a - b; });
+        return out;
+    }
     readonly property int maxOccDesk: {
         var m = 0;
         for (var i = 0; i < root.allWsIds.length; i++)
             m = Math.max(m, root.deskOf(root.allWsIds[i]));
         return Math.max(m, root.activeDesktop);
     }
-    readonly property int newDesktopIdx: root.maxOccDesk + 1
+    readonly property int maxOccDeskGlobal: {
+        var m = 0;
+        for (var i = 0; i < root.globalWsIds.length; i++)
+            m = Math.max(m, root.deskOf(root.globalWsIds[i]));
+        return Math.max(m, root.activeDesktop);
+    }
+    readonly property int newDesktopIdx: root.maxOccDeskGlobal + 1
     // Only desktops that actually hold workspaces, then ONE trailing "add
     // desktop" card. Empty desktops in between are never shown, so the strip
     // stays short (no wall of blank "NEW" cards).
@@ -128,7 +145,7 @@ Item {
     // then close. Unlike switchToDesktop (which only previews in the grid), this
     // actually takes you to the new desktop.
     function createDesktop() {
-        root.switchWs(root.newDesktopIdx * root.perDesktop + 1);
+        root.createAndEnterWs(root.newDesktopIdx * root.perDesktop + 1);
     }
 
     // ---- the viewed desktop's block + its occupancy ---------------------------
@@ -141,17 +158,18 @@ Item {
                 out.push(root.allWsIds[i]);
         return out;
     }
-    // highest 1-based position occupied in this block (0 = desktop empty).
-    readonly property int maxPos: {
-        var m = 0;
-        for (var i = 0; i < root.wsList.length; i++)
-            m = Math.max(m, root.wsList[i] - root.blockBase);
-        return m;
-    }
-    // next free position's id (clamped to the block), for the "+" add slot.
+    // first globally free id in this block, for the "+" add slot. If this
+    // desktop is full, fall through to the next globally empty desktop.
     readonly property int newWsId: {
-        var nx = root.blockBase + root.maxPos + 1;
-        return nx > root.blockBase + root.perDesktop ? root.blockBase + root.perDesktop : nx;
+        var used = ({});
+        for (var i = 0; i < root.globalWsIds.length; i++)
+            used[root.globalWsIds[i]] = true;
+        var lo = root.blockBase + 1;
+        var hi = root.blockBase + root.perDesktop;
+        for (var id = lo; id <= hi; id++)
+            if (!used[id])
+                return id;
+        return root.newDesktopIdx * root.perDesktop + 1;
     }
     // The viewed desktop's occupied workspaces as full live cells, then ONE
     // full-size "+" add cell. Empty / gap positions are not shown, and the add
@@ -283,7 +301,10 @@ Item {
         if (root.selected < 0 || root.selected >= root.slotModel.length)
             return;
         var slot = root.slotModel[root.selected];
-        root.switchWs(slot.add ? root.newWsId : slot.wsId);
+        if (slot.add)
+            root.createAndEnterWs(root.newWsId);
+        else
+            root.switchWs(slot.wsId);
     }
 
     // ---- actions (lua-config hyprland: dispatch via the hl.dsp API) -----------
@@ -316,6 +337,14 @@ Item {
             Hyprland.dispatch('hl.dsp.focus({ workspace = ' + id + ' })');
         });
     }
+    function createAndEnterWs(id) {
+        var mon = root.screenName;
+        root.commitOnClose(function () {
+            if (mon)
+                Hyprland.dispatch('hl.dsp.focus({ monitor = "' + mon + '" })');
+            Hyprland.dispatch('hl.dsp.focus({ workspace = ' + id + ' })');
+        });
+    }
     function focusWindow(tl, addr) {
         root.commitOnClose(function () {
             if (tl && tl.wayland)
@@ -326,7 +355,13 @@ Item {
     }
     function moveWindow(addr, wsId) {
         if (!addr) return;
+        var used = false;
+        for (var i = 0; i < root.globalWsIds.length; i++)
+            if (root.globalWsIds[i] === wsId)
+                used = true;
         Hyprland.dispatch('hl.dsp.window.move({ workspace = ' + wsId + ', window = "address:' + root.normAddr(addr) + '" })');
+        if (!used && root.screenName)
+            Hyprland.dispatch('hl.dsp.workspace.move({ workspace = ' + wsId + ', monitor = "' + root.screenName + '" })');
         Hyprland.refreshToplevels();
         Hyprland.refreshWorkspaces();
     }

--- a/ryoku/shell/quickshell/shell/modules/overview/WorkspaceCell.qml
+++ b/ryoku/shell/quickshell/shell/modules/overview/WorkspaceCell.qml
@@ -461,7 +461,7 @@ Item {
                 cursorShape: Qt.PointingHandCursor
                 onEntered: cell.hovered = true
                 onExited: cell.hovered = false
-                onClicked: if (cell.ov) cell.ov.switchWs(cell.ov.newWsId)
+                onClicked: if (cell.ov) cell.ov.createAndEnterWs(cell.ov.newWsId)
             }
         }
     }


### PR DESCRIPTION
Fixes #88

This fixes the overview + button on secondary monitors picking a workspace id that already belongs to another output.

What changed:

    keep the overview filmstrip monitor-local
    allocate new workspace ids from Hyprland's global workspace list
    focus the clicked monitor before creating an unused workspace id
    apply the same creation path to the NEW desktop card
    avoid stealing an existing workspace from another output during drag/drop
