### PR TITLE
[ryoku] qsbar: allow negative bar gaps for qsbar (top and bottom only)

### DIFF
--- a/ryoku/hub/quickshell/pages/BarStudioPage.qml
+++ b/ryoku/hub/quickshell/pages/BarStudioPage.qml
@@ -656,7 +656,7 @@ Item {
                     Step {
                         anchors.right: parent.right
                         anchors.verticalCenter: parent.verticalCenter
-                        from: 0; to: 64
+                        from: -12; to: 64
                         value: page.qval("barGapTop", 3)
                         onModified: value => page.qset("barGapTop", value)
                     }
@@ -674,7 +674,7 @@ Item {
                     Step {
                         anchors.right: parent.right
                         anchors.verticalCenter: parent.verticalCenter
-                        from: 0; to: 64
+                        from: -12; to: 64
                         value: page.qval("barGapBottom", 0)
                         onModified: value => page.qset("barGapBottom", value)
                     }

--- a/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/Theme.qml
+++ b/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/Theme.qml
@@ -2225,7 +2225,7 @@ Item {
     property int barGapRight: 0
     function clampGap(value) {
         var n = Math.round(Number(value) || 0)
-        return Math.max(0, Math.min(64, n))
+        return Math.max(-12, Math.min(64, n))
     }
     // Lead faces the anchored edge, trail the desktop, so consumers skip barPosition.
     readonly property int barGapLead: barPosition === "bottom" ? barGapBottom : barGapTop


### PR DESCRIPTION
## What changed

Changed hub and qsbar to allow up to -12 bar gaps (only top and bottom) so it fits better when you have high gaps in and out on hyprland.

## Area

ryoku

## How it was tested

Tested on my personal computer, parses correctly and works like a charm on ryoku hub.

## Checklist

- [x] One logical change, with a clear `[area] scope: summary` commit subject.
- [ ] Matching `CHANGELOG.md` updated in the area I touched.
- [x] The git hooks pass locally; I did not use `--no-verify`.
- [x] Lua parses (`luac -p`), shell scripts pass `bash -n`, and QML passes
      `qmllint` where applicable.
- [x] No duplicated config, no dead code, no commented-out code, no em-dash.
- [ ] Docs updated if behavior or layout changed.
