### PR TITLE
[ryoku] windows: move window (silently) bind

### DIFF
--- a/ryoku/hyprland/modules/binds.lua
+++ b/ryoku/hyprland/modules/binds.lua
@@ -82,6 +82,7 @@ for i = 1, 10 do
     local key = i % 10 -- 10 maps to the 0 key
     hl.bind(K(mod .. " + " .. key),          hl.dsp.exec_cmd(ws_helper .. " focus " .. i)) -- focus workspace 1-10 on this desktop
     hl.bind(K(mod .. " + ALT + " .. key),    hl.dsp.exec_cmd(ws_helper .. " move " .. i))  -- move window to workspace 1-10 on this desktop
+    hl.bind(K(mod .. " + SHIFT + " .. key),  hl.dsp.exec_cmd(ws_helper .. " movesilent " .. i))  -- move window silently to workspace 1-10 on this desktop
 end
 
 -- Media and volume keys. ryoku-volume honours the volume panel's BOOST toggle

--- a/ryoku/hyprland/scripts/ryoku-workspace
+++ b/ryoku/hyprland/scripts/ryoku-workspace
@@ -65,6 +65,15 @@ case "$cmd" in
     ws=$(target_ws "${2:?slot 1..$PER required}")
     hyprctl dispatch "hl.dsp.window.move({ workspace = $ws })" >/dev/null
     ;;
+  movesilent)
+    ws=$(target_ws "${2:?slot 1..$PER required}")
+    addr=$(hyprctl activewindow -j | jq -r '.address')
+    hyprctl dispatch "hl.dsp.window.move({
+        workspace = \"$ws\",
+        window = \"address:$addr\",
+        follow = false
+    })" >/dev/null
+    ;;
   hide)
     ws=$(hyprctl activewindow -j 2>/dev/null | jq -r '.workspace.name // empty' || true)
     [[ -z $ws ]] && exit 0


### PR DESCRIPTION
## What changed

Windows can now be moved silently with SUPER + SHIFT + 1-10

## Area

ryoku

## How it was tested

Tested on my personal computer. compiles fine and works fine

## Checklist

- [x] One logical change, with a clear `[area] scope: summary` commit subject.
- [ ] Matching `CHANGELOG.md` updated in the area I touched.
- [x] The git hooks pass locally; I did not use `--no-verify`.
- [x] Lua parses (`luac -p`), shell scripts pass `bash -n`, and QML passes
      `qmllint` where applicable.
- [x] No duplicated config, no dead code, no commented-out code, no em-dash.
- [ ] Docs updated if behavior or layout changed.
