### PR TITLE
[ryoku] Fix negate feature in ryowalls

### DIFF
--- a/ryoku/apps/ryowalls/bin/ryowalls
+++ b/ryoku/apps/ryowalls/bin/ryowalls
@@ -2,7 +2,7 @@
 # Engine for ryowalls: search and download wallpapers (wallhaven + curated /
 # scraped live sources), a palette verb that prints an image's matugen palette for
 # the honest live preview, an adjust verb that grades an image (brightness /
-# contrast / saturation / warmth / vignette) for the editor, and an enhance verb
+# contrast / saturation / warmth / vignette / negate) for the editor, and an enhance verb
 # that AI-upscales an image or video on the GPU with progress. WALLHAVEN_API_KEY
 # raises limits; the palette verb mirrors the daemon's matugen engine so the live preview matches what Set writes.
 set -euo pipefail
@@ -285,7 +285,7 @@ enhance_video() {
 # edge for a fast preview render. src may be a local path or an http(s) url.
 adjust_image() {
 	local src="$1" out="$2"; shift 2
-	local br=0 ct=0 sat=0 warm=0 vig=0 size=0 rmul bmul
+	local br=0 ct=0 sat=0 warm=0 vig=0 neg=0 size=0 rmul bmul
 	while [ $# -gt 0 ]; do
 		case "$1" in
 		--brightness) br="$2"; shift 2 ;;
@@ -293,6 +293,7 @@ adjust_image() {
 		--saturation) sat="$2"; shift 2 ;;
 		--warmth) warm="$2"; shift 2 ;;
 		--vignette) vig=1; shift ;;
+		--negate) neg=1; shift ;;
 		--size) size="$2"; shift 2 ;;
 		*) shift ;;
 		esac
@@ -312,6 +313,7 @@ adjust_image() {
 	args+=(-modulate "$((100 + br)),$((100 + sat)),100")
 	[ "$ct" -ne 0 ] && args+=(-brightness-contrast "0x${ct}")
 	[ "$vig" = 1 ] && args+=(-background black -vignette 0x18)
+	[ "$neg" = 1 ] && args+=(-negate)
 	mkdir -p "$(dirname "$out")" 2>/dev/null || true
 	magick "$in" "${args[@]}" "$out"
 	local rc=$?
@@ -754,7 +756,7 @@ caps)
 	jq -cn --argjson vk "$vk" --argjson up "$up" '{vulkan:$vk,upscaler:$up}'
 	;;
 *)
-	echo "usage: ryowalls search --query <q> --page <n> [--top-range <r>] [--ratios <r>] --json | download <id> <url> | palette <url> | adjust <src> <out> [--brightness N] [--contrast N] [--saturation N] [--warmth N] [--vignette] [--size W] | enhance <path> | moewalls-search [--query <q>] [--page <n>] --json | moewalls-download <id> <url> | extras-search [--query <q>] --json | extras-download <id> <url> | live-list | live-import <src> | local-list [--type <t>] [--query <q>] | local-remove <path>..." >&2
+	echo "usage: ryowalls search --query <q> --page <n> [--top-range <r>] [--ratios <r>] --json | download <id> <url> | palette <url> | adjust <src> <out> [--brightness N] [--contrast N] [--saturation N] [--warmth N] [--vignette] [--negate] [--size W] | enhance <path> | moewalls-search [--query <q>] [--page <n>] --json | moewalls-download <id> <url> | extras-search [--query <q>] --json | extras-download <id> <url> | live-list | live-import <src> | local-list [--type <t>] [--query <q>] | local-remove <path>..." >&2
 	exit 2
 	;;
 esac

--- a/ryoku/apps/ryowalls/quickshell/GradeSheet.qml
+++ b/ryoku/apps/ryowalls/quickshell/GradeSheet.qml
@@ -16,18 +16,19 @@ Item {
     readonly property bool videoMode: !!Wallhaven.selected && Wallhaven.selectedVideo
 
     readonly property var looks: [
-        { label: "Original",  brightness: 0,  contrast: 0,   saturation: 0,    warmth: 0,   vignette: false },
-        { label: "Vivid",     brightness: 4,  contrast: 14,  saturation: 34,   warmth: 6,   vignette: false },
-        { label: "Faded",     brightness: 8,  contrast: -22, saturation: -20,  warmth: 4,   vignette: false },
-        { label: "Cinematic", brightness: -4, contrast: 18,  saturation: -8,   warmth: 12,  vignette: true },
-        { label: "Noir",      brightness: 0,  contrast: 22,  saturation: -100, warmth: 0,   vignette: true },
-        { label: "Warm",      brightness: 3,  contrast: 6,   saturation: 10,   warmth: 46,  vignette: false },
-        { label: "Cool",      brightness: 2,  contrast: 8,   saturation: 8,    warmth: -44, vignette: false }
+        { label: "Original",  brightness: 0,  contrast: 0,   saturation: 0,    warmth: 0,   vignette: false, negate: false },
+        { label: "Vivid",     brightness: 4,  contrast: 14,  saturation: 34,   warmth: 6,   vignette: false, negate: false },
+        { label: "Faded",     brightness: 8,  contrast: -22, saturation: -20,  warmth: 4,   vignette: false, negate: false },
+        { label: "Cinematic", brightness: -4, contrast: 18,  saturation: -8,   warmth: 12,  vignette: true,  negate: false },
+        { label: "Noir",      brightness: 0,  contrast: 22,  saturation: -100, warmth: 0,   vignette: true,  negate: false },
+        { label: "Warm",      brightness: 3,  contrast: 6,   saturation: 10,   warmth: 46,  vignette: false, negate: false },
+        { label: "Cool",      brightness: 2,  contrast: 8,   saturation: 8,    warmth: -44, vignette: false, negate: false }
     ]
     function lookActive(l) {
         var a = Wallhaven.adjust;
         return a.brightness === l.brightness && a.contrast === l.contrast
-            && a.saturation === l.saturation && a.warmth === l.warmth && a.vignette === l.vignette;
+            && a.saturation === l.saturation && a.warmth === l.warmth && a.vignette === l.vignette
+            && a.negate === l.negate;
     }
     function currentLook() {
         for (var i = 0; i < looks.length; i++)
@@ -164,8 +165,22 @@ Item {
                     Sw {
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.right: parent.right
-                        on: Wallhaven.adjust.vignette
+                        on: !!Wallhaven.adjust.vignette
                         onToggled: (v) => Wallhaven.setAdjust("vignette", v)
+                    }
+                }
+                Cell {
+                    width: gradeSec.span(4)
+                    label: I18n.tr("Negate")
+                    value: Wallhaven.adjust.negate ? "ON" : "OFF"
+                    def: "OFF"
+                    desc: I18n.tr("Invert the colours. Baked in on Set.")
+                    controlWidth: Spans.inlineWidth("sw", 0, width)
+                    Sw {
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.right: parent.right
+                        on: !!Wallhaven.adjust.negate
+                        onToggled: (v) => Wallhaven.setAdjust("negate", v)
                     }
                 }
             }

--- a/ryoku/apps/ryowalls/quickshell/Singletons/Wallhaven.qml
+++ b/ryoku/apps/ryowalls/quickshell/Singletons/Wallhaven.qml
@@ -206,14 +206,14 @@ Singleton {
     }
 
     // ---- adjust: grade the picked image (brightness/contrast/saturation/warmth,
-    // vignette) live, then bake it on Set. Session-only, reset when the pick
+    // vignette, negate) live, then bake it on Set. Session-only, reset when the pick
     // changes. The graded preview drives both the rice mock and its palette, so
     // what you see is what Set writes. Videos can't be graded (canAdjust=false).
-    property var adjust: ({ brightness: 0, contrast: 0, saturation: 0, warmth: 0, vignette: false })
+    property var adjust: ({ brightness: 0, contrast: 0, saturation: 0, warmth: 0, vignette: false, negate: false })
     property string adjustPreview: ""     // graded temp image url for the live preview
     property int adjustRev: 0
     readonly property bool adjustActive: adjust.brightness !== 0 || adjust.contrast !== 0
-        || adjust.saturation !== 0 || adjust.warmth !== 0 || adjust.vignette
+        || adjust.saturation !== 0 || adjust.warmth !== 0 || adjust.vignette || adjust.negate
     readonly property bool canAdjust: !!selected && !selectedVideo
 
     readonly property string _adjDir: (Quickshell.env("XDG_CACHE_HOME") || (Quickshell.env("HOME") + "/.cache")) + "/ryoku"
@@ -222,22 +222,23 @@ Singleton {
         var f = ["--brightness", "" + adjust.brightness, "--contrast", "" + adjust.contrast,
                  "--saturation", "" + adjust.saturation, "--warmth", "" + adjust.warmth];
         if (adjust.vignette) f.push("--vignette");
+        if (adjust.negate) f.push("--negate");
         return f;
     }
     function setAdjust(key, val) {
         var a = { brightness: adjust.brightness, contrast: adjust.contrast,
-                  saturation: adjust.saturation, warmth: adjust.warmth, vignette: adjust.vignette };
+                  saturation: adjust.saturation, warmth: adjust.warmth, vignette: adjust.vignette, negate: adjust.negate };
         a[key] = val;
         adjust = a;
         _adjDebounce.restart();
     }
     function applyLook(look) {
         adjust = { brightness: look.brightness || 0, contrast: look.contrast || 0,
-                   saturation: look.saturation || 0, warmth: look.warmth || 0, vignette: !!look.vignette };
+                   saturation: look.saturation || 0, warmth: look.warmth || 0, vignette: !!look.vignette, negate: !!look.negate };
         _adjDebounce.restart();
     }
     function resetAdjust() {
-        adjust = { brightness: 0, contrast: 0, saturation: 0, warmth: 0, vignette: false };
+        adjust = { brightness: 0, contrast: 0, saturation: 0, warmth: 0, vignette: false, negate: false };
         adjustPreview = "";
         _preview();
     }
@@ -450,7 +451,7 @@ Singleton {
         // a lingering enhance verdict belongs to the previous pick; a run still in
         // flight keeps its status so its finish is never silent.
         if (!enhancing) _enhReset();
-        adjust = { brightness: 0, contrast: 0, saturation: 0, warmth: 0, vignette: false };
+        adjust = { brightness: 0, contrast: 0, saturation: 0, warmth: 0, vignette: false, negate: false };
         adjustPreview = "";
         _preview();
     }


### PR DESCRIPTION
## Fix negate feature in ryowalls


addded The negate (color inversion) feature in ryowalls 
### Files Changed
- `ryoku/apps/ryowalls/bin/ryowalls` - Add `--negate` flag support
- `ryoku/apps/ryowalls/quickshell/GradeSheet.qml` - Fix UI and look presets
- `ryoku/apps/ryowalls/quickshell/Singletons/Wallhaven.qml` - Fix state management

### Testing
- Wallpaper browsing works normally
- Selecting wallpapers resets adjustments correctly
- Switching between look presets preserves negate state
- The Negate toggle works independently