### PR TITLE
Fix plugin popout dimensions and dismiss

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -83,8 +83,22 @@ surface at a time, so they take turns rather than overlap.
 
 - Ryoku handles the **hover trigger, the open/close animation, and the fuse into
   the frame**.
-- The popout **grows to fit your content** - it's exactly as tall as your view
-  needs, with even padding. You never set the popout's width or height.
+- **Dimensions & Sizing**:
+  - By default, edge popouts use a compact `360px` width budget and grow vertically
+    to fit your content's `implicitHeight`.
+  - For rich or modal views (calculators, email, system monitors), you can specify
+    a custom width and height:
+    - **In manifest defaults**: declare `"width"` and/or `"height"` under `defaults.framePopout`.
+    - **In plugin settings**: declare `"width"` and/or `"height"` controls in `metadata.settings`.
+      Ryoku Settings will expose them directly to users, and the popout will resize live.
+    - **Implicit fallback**: if no fixed setting is set, Ryoku respects your root
+      `implicitWidth` (falling back to standard 680px for centered popouts).
+- **Dismissal & Lifecycle**:
+  - **Edge hover popouts** auto-retract after the pointer leaves (`autoDismiss: true`).
+  - **Centered modal popouts** stay open until explicitly closed via `Escape`, clicking
+    outside, or toggling the shortcut (`autoDismiss: false`).
+  - To override this behavior on any popout, set `"autoDismiss": true` or `false`
+    in `defaults.framePopout`.
 
 `ryoku-shell plugin <id>` toggles your frame popout open (bind it to a key).
 
@@ -220,7 +234,13 @@ to `plugins.json`; read the live values from `pluginApi.pluginSettings`.
   "hosts": ["framePopout", "desktopWidget"],
   "defaults": {
     "host": "framePopout",
-    "framePopout": { "edge": "top", "align": "end" },
+    "framePopout": {
+      "edge": "center",
+      "align": "center",
+      "width": 680,
+      "height": 520,
+      "autoDismiss": false
+    },
     "icon": "image",
     "label": "Your Plugin"
   },

--- a/ryoku/shell/quickshell/shell/modules/bar/PluginPopouts.qml
+++ b/ryoku/shell/quickshell/shell/modules/bar/PluginPopouts.qml
@@ -141,28 +141,49 @@ Item {
             // travel to the fresh popout; once it has arrived (`_touched`),
             // leaving for `_graceMs` clears the pin. timer also catches a
             // hover-leave a masked layer surface can otherwise miss.
+            readonly property bool autoDismiss: (place.framePopout && place.framePopout.autoDismiss !== undefined)
+                ? place.framePopout.autoDismiss
+                : !pop.centered
             property bool _touched: false
             readonly property int _graceMs: 2500
             onHoveredChanged: {
+                if (!pop.autoDismiss) return;
                 if (pop.hovered) { pop._touched = true; graceTimer.stop(); }
                 else if (pop.pinned) graceTimer.restart();
             }
             onPinnedChanged: {
                 pop._touched = false;
+                if (!pop.autoDismiss) {
+                    graceTimer.stop();
+                    return;
+                }
                 if (pop.pinned) graceTimer.restart(); else graceTimer.stop();
             }
             Timer {
                 id: graceTimer
                 interval: pop._touched ? 220 : pop._graceMs
-                onTriggered: if (pop.pinned && !pop.hovered) root.unpinRequested(pop.modelData);
+                onTriggered: if (pop.autoDismiss && pop.pinned && !pop.hovered) root.unpinRequested(pop.modelData);
             }
             // body fits content vertically. openH = loaded content's intrinsic
             // height + inner pad, so no deadspace. width is fixed (content lays
             // out to contentW); content is inset by `pad` so nothing sits flush
             // against the edges.
             readonly property real pad: 16 * root.s
-            readonly property real contentW: 360 * root.s
-            readonly property real contentH: contentLoader.item ? contentLoader.item.implicitHeight : 420 * root.s
+            readonly property var sObj: (place && place.settings) ? place.settings : ({})
+            readonly property real contentW: ((sObj && sObj.width && Number(sObj.width) > 0)
+                ? Number(sObj.width)
+                : ((place.framePopout && place.framePopout.width && place.framePopout.width > 0)
+                    ? place.framePopout.width
+                    : ((contentLoader.item && contentLoader.item.implicitWidth > 0)
+                        ? contentLoader.item.implicitWidth
+                        : 680))) * root.s
+            readonly property real contentH: ((sObj && sObj.height && Number(sObj.height) > 0)
+                ? Number(sObj.height)
+                : ((place.framePopout && place.framePopout.height && place.framePopout.height > 0)
+                    ? place.framePopout.height
+                    : ((contentLoader.item && contentLoader.item.implicitHeight > 0)
+                        ? contentLoader.item.implicitHeight
+                        : 520))) * root.s
             openW: contentW + pad * 2
             openH: contentH + pad * 2
             hoverW: (place.framePopout && place.framePopout.hoverW) ? place.framePopout.hoverW * root.s : 0

--- a/ryoku/shell/quickshell/shell/modules/bar/popouts/Popout.qml
+++ b/ryoku/shell/quickshell/shell/modules/bar/popouts/Popout.qml
@@ -110,7 +110,7 @@ Item {
     // bar module): a click-pinned popout must close the moment it's unpinned
     // (close button, Escape, keybind re-toggle), even under the pointer.
     readonly property bool hovered: (hoverOpen && triggerHH.hovered) || triggerHovered
-        || (bodyHH.hovered && (hoverOpen || closeDelay > 0))
+        || (bodyHH.hovered && (hoverOpen || centered || closeDelay > 0))
     // host gates this off while a centre surface is open or a window is
     // fullscreen, so an edge hover never fights a modal surface.
     property bool active: true


### PR DESCRIPTION
<!-- Keep one logical change per pull request. See CONTRIBUTING.md. -->

## What changed
This PR resolves two related friction points in the frame popout subsystem that prevent plugin developers from building rich, standalone popout applications (such as mail clients, kanban boards, system monitors, or calculators):
1. **Dynamic Popout Sizing via Settings & Manifest (`PluginPopouts.qml`):**
   - **Problem:** `PluginPopouts.qml` hardcoded `contentW: 360 * root.s` and forced `content.widthBudget = pop.contentW`. Any custom width/height declared in a plugin's `manifest.json` under `defaults.framePopout` or exposed in `metadata.settings` (e.g. width presets in Ryoku Settings) was completely ignored, crushing any view wider than a narrow 360px rail.
   - **Fix:** Popouts now resolve width and height with cascading fallback:
     `user settings (live from Ryoku Settings)` → `manifest framePopout dimensions` → `content's implicit size` → `default fallback (680 x 520)`. Plugin developers can now size their popouts to fit their application's exact design needs.
2. **Hover Detection & Unwanted Auto-Dismiss on Centered Popouts (`Popout.qml` & `PluginPopouts.qml`):**
   - **Problem:** Centered popouts (`edge: "center"`) explicitly disable edge hover (`hoverOpen: false`). However, `Popout.qml` guarded its body hover check behind `bodyHH.hovered && (hoverOpen || closeDelay > 0)`. Because `hoverOpen` was false, `pop.hovered` evaluated to `false` permanently, even while the user was actively typing or clicking inside the popout. Consequently, `PluginPopouts.qml`'s 2.5-second `graceTimer` always timed out and fired `root.unpinRequested()`, causing modal popouts to spontaneously vanish after ~5 seconds.
   - **Fix:** Added `centered` to the body hover check in `Popout.qml`. Furthermore, added an `autoDismiss` property in `PluginPopouts.qml` (defaulting to `false` for centered modal popouts or when declared in plugin metadata), ensuring interactive tools stay open until explicitly dismissed via Escape, backdrop click, or keybind toggle.


## Area

Plugin System | docs

<!-- The commit subject area: global | installation | system | ryoku | docs | test | tooling | release -->

## How it was tested

- Verified on live `quickshell` shell daemon with multiple plugins (standard 360px popouts, Stargate desktop widget, and 680px centered popouts).
- Changed width and height presets in **Ryoku Settings -> Plugins**: popout resized dynamically.
- Verified closing mechanics: closes immediately on Escape, backdrop press, or toggling `ryoku-shell plugin <id>`.
- Verified `edge: "top"` hover popouts still preserve their normal hover-open and auto-dismiss behavior.


## Checklist

- [Y ] One logical change, with a clear `[area] scope: summary` commit subject.
- [Y ] Matching `CHANGELOG.md` updated in the area I touched.
- [Y ] The git hooks pass locally; I did not use `--no-verify`.
- [Y ] Lua parses (`luac -p`), shell scripts pass `bash -n`, and QML passes
      `qmllint` where applicable.
- [Y ] No duplicated config, no dead code, no commented-out code, no em-dash.
- [Y ] Docs updated if behavior or layout changed.
