### PR TITLE
Update installation instructions and add NixOS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Broadcom Wi-Fi, read-only NVRAM, slow USB media) is in
 
 ## Install
 
-Two ways in. A fresh machine boots the signed **ISO**; an existing Arch box
+Three ways in. A fresh machine boots the signed **ISO**; an existing Arch box
 converts in place with the **shell installer**.
 
 ### Fresh install (the ISO)
@@ -209,6 +209,27 @@ curl -fsSL https://raw.githubusercontent.com/neur0map/ryoku-arch/main/ryoku-shel
 Preview everything it would do without changing anything by appending
 `-s -- --dry-run` after `bash`. Details in
 [`ryoku-shell-installer/`](ryoku-shell-installer/README.md).
+
+
+### Ryoku on NixOS
+
+An official NixOS port of the Ryoku desktop is available for users who want
+Ryoku integrated declaratively into an existing NixOS system.
+
+The NixOS implementation is maintained separately so that its packaging,
+system integration, updates, and release lifecycle can follow Nix conventions
+without affecting the Arch implementation.
+
+[**View Ryoku on NixOS →**](https://github.com/Aetherelic/Ryoku-on-NixOS)
+
+
+## Install on an existing flake-based NixOS system:
+
+```bash
+nix run github:Aetherelic/Ryoku-on-NixOS/main#install
+```
+Ryoku on NixOS is maintained by [Aether](https://github.com/Aetherelic)
+
 
 > [!WARNING]
 > The shell installer is young and still being tested across different hardware,


### PR DESCRIPTION
Added instructions for installing Ryoku on NixOS and updated installation methods.

<!-- Keep one logical change per pull request. See CONTRIBUTING.md. -->

## What changed

Describe the change and why it is needed.

## Area

<!-- The commit subject area: global | installation | system | ryoku | docs | test | tooling | release -->

## How it was tested

Describe how you verified this on a running system, not only that it parses.

## Checklist

- [ ] One logical change, with a clear `[area] scope: summary` commit subject.
- [ ] Matching `CHANGELOG.md` updated in the area I touched.
- [ ] The git hooks pass locally; I did not use `--no-verify`.
- [ ] Lua parses (`luac -p`), shell scripts pass `bash -n`, and QML passes
      `qmllint` where applicable.
- [ ] No duplicated config, no dead code, no commented-out code, no em-dash.
- [ ] Docs updated if behavior or layout changed.
