### PR TITLE
[ryoku] make beta edition labels dynamic

### DIFF
--- a/docs/ui-ux.md
+++ b/docs/ui-ux.md
@@ -347,7 +347,8 @@ not look broken; it looks fine and then eats the edit on the way out.
   `adv` folds away entirely rather than leaving a bare header. Search still
   reaches them, and the open section always counts as visible, so turning
   Advanced off never strands you on a page the rail no longer lists.
-- **The rail foot.** A `Barcode`, the edition chip (`BETA // 18`), the `RYOKU
+- **The rail foot.** A `Barcode`, the edition chip (driven by `ryoku version`,
+  e.g. `BETA // 19` on beta builds), the `RYOKU
   HUB` label, and that Advanced switch.
 - **The page head.** A `力 <GROUP>` eyebrow, the title in Fraunces at `fTitle`,
   and a one-sentence description.

--- a/ryoku/apps/ryovm/quickshell/Rail.qml
+++ b/ryoku/apps/ryovm/quickshell/Rail.qml
@@ -180,7 +180,7 @@ Item {
         Marginalia {
             id: edition
             anchors { left: parent.left; top: parent.top; topMargin: Tokens.s3 }
-            index: "BETA"; label: "18"
+            index: "BETA"; label: "19"
             glyph: "column"; glyph2: ""
             chevrons: false
         }

--- a/ryoku/apps/ryovm/quickshell/Rail.qml
+++ b/ryoku/apps/ryovm/quickshell/Rail.qml
@@ -180,7 +180,7 @@ Item {
         Marginalia {
             id: edition
             anchors { left: parent.left; top: parent.top; topMargin: Tokens.s3 }
-            index: "BETA"; label: "19"
+            index: Version.editionIndex; label: Version.editionNumber
             glyph: "column"; glyph2: ""
             chevrons: false
         }

--- a/ryoku/hub/quickshell/Hub.qml
+++ b/ryoku/hub/quickshell/Hub.qml
@@ -991,7 +991,7 @@ Rectangle {
             Marginalia {
                 id: edition
                 anchors { left: parent.left; top: parent.top; topMargin: Tokens.s3 }
-                index: "BETA"; label: "18"
+                index: "BETA"; label: "19"
                 glyph: "column"; glyph2: ""
                 chevrons: false
             }

--- a/ryoku/hub/quickshell/Hub.qml
+++ b/ryoku/hub/quickshell/Hub.qml
@@ -991,7 +991,7 @@ Rectangle {
             Marginalia {
                 id: edition
                 anchors { left: parent.left; top: parent.top; topMargin: Tokens.s3 }
-                index: "BETA"; label: "19"
+                index: Version.editionIndex; label: Version.editionNumber
                 glyph: "column"; glyph2: ""
                 chevrons: false
             }

--- a/ryoku/hub/quickshell/pages/ProfilePage.qml
+++ b/ryoku/hub/quickshell/pages/ProfilePage.qml
@@ -82,7 +82,7 @@ Item {
         if (k === "net")
             return "\u2193 " + pg.fmtRate(LiveStats.netDown);
         if (k === "frac")
-            return "BETA · 18";
+            return "BETA · 19";
         return "";
     }
     function statSub(k) {

--- a/ryoku/hub/quickshell/pages/ProfilePage.qml
+++ b/ryoku/hub/quickshell/pages/ProfilePage.qml
@@ -82,7 +82,7 @@ Item {
         if (k === "net")
             return "\u2193 " + pg.fmtRate(LiveStats.netDown);
         if (k === "frac")
-            return "BETA · 19";
+            return Version.editionSummary;
         return "";
     }
     function statSub(k) {
@@ -95,7 +95,7 @@ Item {
         if (k === "net")
             return "\u2191 " + pg.fmtRate(LiveStats.netUp);
         if (k === "frac")
-            return "STABLE";
+            return Version.editionIndex;
         return "";
     }
 

--- a/ryoku/ui/Singletons/Version.qml
+++ b/ryoku/ui/Singletons/Version.qml
@@ -1,0 +1,57 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// One source for the shipped Ryoku edition strings every surface shows. The CLI
+// already knows how to resolve the version from a checkout and from an installed
+// package, so QML asks it once and parses the prerelease tag.
+Singleton {
+    id: root
+
+    property string rawVersion: ""
+
+    readonly property string editionIndex: {
+        const parsed = root.parseVersion(root.rawVersion);
+        return parsed.index;
+    }
+
+    readonly property string editionNumber: {
+        const parsed = root.parseVersion(root.rawVersion);
+        return parsed.number;
+    }
+
+    readonly property string editionSummary: {
+        return root.editionNumber.length > 0
+            ? root.editionIndex + " · " + root.editionNumber
+            : root.editionIndex;
+    }
+
+    function parseVersion(text) {
+        const clean = (text || "").trim();
+        const dash = clean.indexOf("-");
+        if (dash < 0)
+            return { index: "STABLE", number: "" };
+
+        const prerelease = clean.slice(dash + 1).trim();
+        const parts = prerelease.split(".");
+        const tail = parts.length > 0 ? parts[parts.length - 1] : "";
+        const head = parts.slice(0, -1).join(" ").trim();
+        if (!/^\d+$/.test(tail) || head.length === 0)
+            return { index: "STABLE", number: "" };
+        return { index: head.toUpperCase(), number: tail };
+    }
+
+    function refresh() {
+        versionProc.running = true;
+    }
+
+    Process {
+        id: versionProc
+        command: ["sh", "-c", "ryoku version 2>/dev/null"]
+        stdout: StdioCollector { onStreamFinished: root.rawVersion = this.text.trim() }
+    }
+
+    Component.onCompleted: refresh()
+}

--- a/ryoku/ui/Singletons/qmldir
+++ b/ryoku/ui/Singletons/qmldir
@@ -9,3 +9,4 @@ singleton DecorStore DecorStore.qml
 singleton Ryodecors Ryodecors.qml
 singleton ProfileStore ProfileStore.qml
 singleton Spawn Spawn.qml
+singleton Version Version.qml


### PR DESCRIPTION
## What this fixes
The Hub, profile page, and ryovm rail were showing a hardcoded beta edition label.

That meant the visible edition chip had to be manually updated for every beta release, which is easy to forget and lets the UI drift out of sync with the actual Ryoku version.

## What changed
- added a shared QML version singleton that reads `ryoku version`
- parse prerelease versions like `v0.49.9-beta.19` into the visible edition label
- updated the Hub rail, profile page, and ryovm rail to use that shared dynamic source
- updated the UI docs to describe the new behavior instead of a fixed beta number

Now the UI follows the real version string instead of baking in a specific beta label.