### PR TITLE
[global] bar: restore bolt-2 bar gap animation in bar studio and shell

### DIFF
--- a/ryoku/hub/quickshell/pages/BarStudioPage.qml
+++ b/ryoku/hub/quickshell/pages/BarStudioPage.qml
@@ -232,6 +232,7 @@ Item {
         { v: 1, label: qsTr("Stream") },
         { v: 2, label: qsTr("Surge") },
         { v: 3, label: qsTr("Bolt") },
+	{ v: 4, label: qsTr("Bolt-2") },
         { v: 7, label: qsTr("Reactor") },
         { v: 8, label: qsTr("Quotes") }
     ]

--- a/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/controlcenter/routes/BarsRoute.qml
+++ b/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/controlcenter/routes/BarsRoute.qml
@@ -49,6 +49,7 @@ Item {
         { v: 1, label: "Stream" },
         { v: 2, label: "Surge" },
         { v: 3, label: "Bolt" },
+	{ v: 4, label: "Bolt-2"},
         { v: 7, label: "Reactor" },
         { v: 8, label: "Quotes" }
     ]


### PR DESCRIPTION
## What changed

Exposes the "bolt-2" bar gap animation option in both Bar Studio and the Control Center Bars route.

- Adds "bolt-2" to the animation choices in `BarStudioPage.qml`.
- Adds "bolt-2" to the available bar animation options in `BarsRoute.qml`.
- Reuses the existing backend animation handler so the preset can be selected from the UI.

<img width="967" height="111" alt="2026_09_01_18_19_36_screenshot" src="https://github.com/user-attachments/assets/cbe4874a-d6f6-4fd7-a257-d868abf28bba" />
<img width="734" height="147" alt="2026_09_01_18_19_12_screenshot" src="https://github.com/user-attachments/assets/33149d69-1278-45a5-8050-5a3369184c5a" />


## Area

global

## How it was tested

- Deployed the shell via deploy.sh in an Arch Linux VM.
- Selected "bolt-2" in settings and via the shell studio and verified the bar gap animation renders as expected.
- Verified that the setting persists across saves and reloads.

## Checklist

- [x] One logical change, with a clear `[area] scope: summary` commit subject.
- [x] Matching `CHANGELOG.md` updated in the area I touched.
- [x] The git hooks pass locally; I did not use `--no-verify`.
- [x] Lua parses (`luac -p`), shell scripts pass `bash -n`, and QML passes
      `qmllint` where applicable.
- [x] No duplicated config, no dead code, no commented-out code, no em-dash.
- [x] Docs updated if behavior or layout changed.
