### PR TITLE
[ryoku] keyboard layout widget and osd

### DIFF
--- a/ryoku/hub/quickshell/pages/BarStudioPage.qml
+++ b/ryoku/hub/quickshell/pages/BarStudioPage.qml
@@ -289,7 +289,8 @@ Item {
         { id: "bluetooth", label: qsTr("Bluetooth"), def: false, desc: qsTr("Bluetooth pill.") },
         { id: "gpu", label: qsTr("GPU"), def: true, desc: qsTr("GPU load.") },
         { id: "cpuTemperature", label: qsTr("CPU temperature"), def: true, desc: qsTr("CPU temperature.") },
-        { id: "storage", label: qsTr("Storage"), def: true, desc: qsTr("Root filesystem usage.") }
+        { id: "storage", label: qsTr("Storage"), def: true, desc: qsTr("Root filesystem usage.") },
+        { id: "layout", label: qsTr("Keyboard Layout"), def: true, desc: qsTr("Current keyboard layout.") }
     ]
     readonly property var qsbarColors: ["color01", "color02", "color03", "color04", "color05", "color06", "color07", "foreground"]
     property var qsbarPalette: ({})

--- a/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/BarSlot.qml
+++ b/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/BarSlot.qml
@@ -1052,6 +1052,15 @@ PanelWindow {
         }
     }
     Component {
+        id: compLayout
+
+        LayoutWidget {
+            root: barSlot.root
+            readonly property real barContentLeftInset: 9
+            readonly property real barContentRightInset: 9
+        }
+    }
+    Component {
         id: compClaude
         ClaudeWidget {
             root: barSlot.root
@@ -1291,7 +1300,7 @@ PanelWindow {
         "G8": compCenter,
         "G9": compMpris, "G10": compQuick, "G11": compNetwork,
         "G12": compBattery, "G13": compBrightness, "G14": compPower, "G15": compBluetooth,
-        "G16": compCpuTemperature, "G17": compGpu, "G18": compStorage
+        "G16": compCpuTemperature, "G17": compGpu, "G18": compStorage, "G19": compLayout
     })
 
     // ───────────────────── reusable region row of slots ─────────────────────
@@ -2103,7 +2112,7 @@ PanelWindow {
             ListElement { gid: "G9"; extra: false }  ListElement { gid: "G10"; extra: false } ListElement { gid: "G11"; extra: false }
             ListElement { gid: "G14"; extra: false } ListElement { gid: "G12"; extra: false } ListElement { gid: "G13"; extra: false }
             ListElement { gid: "G16"; extra: false } ListElement { gid: "G18"; extra: true }  ListElement { gid: "G17"; extra: true }
-            ListElement { gid: "G15"; extra: true }  ListElement { gid: ""; extra: true }     ListElement { gid: ""; extra: true }
+            ListElement { gid: "G15"; extra: true }  ListElement { gid: "G19"; extra: true }     ListElement { gid: ""; extra: true }
             ListElement { gid: ""; extra: true }
         }
 

--- a/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/Theme.qml
+++ b/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/Theme.qml
@@ -1783,6 +1783,7 @@ Item {
     property bool modVolume:     true
     property bool modWeather:    true
     property bool modNetwork:    true
+    property bool modLayout:     true
     property string networkMode: "none"   // mirrored from NetworkWidget: wifi/ethernet/none
     // Centralized status indicators. These live on Theme so BarSlot-per-monitor
     // widgets don't each spawn their own status poller.
@@ -2305,7 +2306,7 @@ Item {
         var m = String(gid || "").match(/^G(\d{1,2})$/)
         if (!m) return false
         var n = Number(m[1])
-        return n >= 1 && n <= 18
+        return n >= 1 && n <= 19
     }
     function widgetColorModeValid(mode) {
         return mode === "fill" || mode === "border" || mode === "both"
@@ -2477,7 +2478,7 @@ Item {
     }
     function serializeWidgetColorStyles() {
         var out = []
-        for (var n = 1; n <= 18; n++) {
+        for (var n = 1; n <= 19; n++) {
             var gid = "G" + n
             var style = widgetColorStyle(gid)
             if (style.color !== "inherit" || style.mode === "border")
@@ -2598,6 +2599,7 @@ Item {
                  + (barBorderEnabled ? "1" : "0") + " "                 // +43 outer bar border
                  + (panelTooltipBorderEnabled ? "1" : "0") + " "        // +44 panel + tooltip outer border
                  + barAnim                                              // +45 gap-animation mode
+                 + (modLayout ? "1" : "0")                              // +46 keyboard layout
         widgetSaveProc.command = ["bash", "-c",
             "echo '" + line + "' > '" + widgetsCachePath + "'"]
         widgetSaveProc.running = false
@@ -2793,6 +2795,8 @@ Item {
                         var ba = parseInt(parts[wsField + 45], 10)
                         if (isFinite(ba) && ba >= 0 && ba <= 8) theme.barAnim = ba
                     }
+                    if (parts.length > wsField + 46)
+                        theme.modLayout = parts[wsField + 46] !== "0"
                 }
                 theme._widgetsLoaded = true
                 theme.applyStudioSettings()
@@ -2849,7 +2853,7 @@ Item {
             "media": modMedia, "mpris": modMpris, "quick": modQuick, "claude": modClaude,
             "power": modPower, "bluetooth": modBluetooth, "gpu": modGpu,
             "cpuTemperature": modCpuTemperature, "storage": modStorage,
-            "battery": modBattery
+            "battery": modBattery, "layout": modLayout
         }
         _cfgCtl.queued += "call settings.patch " + JSON.stringify({ path: "qsbar", value: q }) + "\n"
         if (_cfgCtl.connected) _cfgCtl.flushQueued()
@@ -2923,6 +2927,7 @@ Item {
             if (w.cpuTemperature !== undefined) modCpuTemperature = w.cpuTemperature
             if (w.storage        !== undefined) modStorage        = w.storage
             if (w.battery        !== undefined) modBattery        = w.battery
+            if (w.layout         !== undefined) modLayout         = w.layout
         }
         _widgetsLoaded = wl
     }

--- a/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/controlcenter/routes/AppearanceRoute.qml
+++ b/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/controlcenter/routes/AppearanceRoute.qml
@@ -280,6 +280,7 @@ Item {
                         WidgetCard { width: widgetGrid.cellW; visible: page.root && page.root.modGpu !== undefined;            modProp: "modGpu";            gid: "G17"; flag: "compactGpu";            title: "GPU" }
                         WidgetCard { width: widgetGrid.cellW; visible: page.root && page.root.modCpuTemperature !== undefined; modProp: "modCpuTemperature"; gid: "G16"; flag: "compactCpuTemperature"; title: "CPU Temp" }
                         WidgetCard { width: widgetGrid.cellW; visible: page.root && page.root.modStorage !== undefined;        modProp: "modStorage";        gid: "G18"; flag: "compactStorage";        title: "Storage" }
+                        WidgetCard { width: widgetGrid.cellW; modProp: "modLayout"; gid: "G19"; flag: "compactLayout"; title: "Keyboard Layout" }
                     }
                 }
             }

--- a/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/modules/LayoutWidget.qml
+++ b/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/modules/LayoutWidget.qml
@@ -1,0 +1,99 @@
+import QtQuick
+import Quickshell
+import shell.services
+
+Item {
+    id: rootMod
+    required property var root
+
+    readonly property bool iconOnly: root.iconOnly("G19")
+
+    property string layout: {
+        var value = KeyboardLayout.variant || ""
+        if (!value)
+            return ""
+
+        var match = value.match(/\(([^)]+)\)/)
+        return match ? match[1].toUpperCase() : value.toUpperCase()
+    }
+
+    readonly property string layoutIcon: "keyboard"
+    readonly property color contentColor: root.widgetContentColor("G19", root.widgetIconColor)
+
+    readonly property string tooltipText: "Keyboard layout · " + rootMod.layout
+
+    visible: implicitWidth > 0.5
+    implicitWidth: root.modLayout ? row.implicitWidth + 18 : 0
+    implicitHeight: 28
+    opacity: root.modLayout ? 1 : 0
+
+    Behavior on opacity {
+        NumberAnimation {
+            duration: 140
+            easing.type: Easing.OutCubic
+        }
+    }
+
+    Row {
+        id: row
+
+        anchors.centerIn: parent
+        spacing: 4
+
+        IconText {
+            anchors.verticalCenter: parent.verticalCenter
+
+            text: rootMod.layoutIcon
+            color: rootMod.contentColor
+
+            font.pixelSize: 15
+            font.weight: Font.Medium
+            fill: 1
+
+            Behavior on color {
+                ColorAnimation {
+                    duration: 160
+                }
+            }
+        }
+
+        UiText {
+            visible: !root.iconOnly("G19")
+
+            anchors.verticalCenter: parent.verticalCenter
+
+            text: rootMod.layout
+            color: rootMod.contentColor
+
+            font.family: root.mono
+            font.pixelSize: 12
+
+            Behavior on color {
+                ColorAnimation {
+                    duration: 160
+                }
+            }
+        }
+    }
+
+    TooltipMixin {
+        id: tip
+        root: rootMod.root
+        owner: rootMod
+        text: rootMod.tooltipText
+    }
+
+    MouseArea {
+        anchors.fill: parent
+
+        hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
+
+        onEntered: tip.show()
+        onExited: tip.hide()
+
+        onClicked: {
+            tip.hide()
+        }
+    }
+}

--- a/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/modules/qmldir
+++ b/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/modules/qmldir
@@ -17,6 +17,7 @@ IconText IconText.qml
 IdleInhibitorWidget IdleInhibitorWidget.qml
 IdleWidget IdleWidget.qml
 LauncherWidget LauncherWidget.qml
+LayoutWidget LayoutWidget.qml
 MediaBrowserWidget MediaBrowserWidget.qml
 MemoryWidget MemoryWidget.qml
 MprisArtwork MprisArtwork.qml

--- a/ryoku/shell/quickshell/shell/modules/osd/KeyboardOsd.qml
+++ b/ryoku/shell/quickshell/shell/modules/osd/KeyboardOsd.qml
@@ -1,0 +1,43 @@
+import QtQuick
+import shell.services
+import "../../components"
+
+Item {
+    id: root
+
+    property real us: 1
+
+    readonly property string layout: KeyboardLayout.variant || "Unknown"
+
+    implicitWidth: content.implicitWidth
+    implicitHeight: content.implicitHeight
+
+    Row {
+        id: content
+
+        anchors.centerIn: parent
+        spacing: 8 * root.us
+
+        Text {
+            text: "⌨ "
+            color: Theme.onSurface
+
+            font.pixelSize: 20 * root.us
+            font.family: Theme.mono
+
+            anchors.verticalCenter: parent.verticalCenter
+        }
+
+        Text {
+            text: root.layout
+            color: Theme.onSurface
+
+            font.family: Theme.mono
+            font.pixelSize: Theme.fontMd * root.us
+
+            verticalAlignment: Text.AlignVCenter
+
+            anchors.verticalCenter: parent.verticalCenter
+        }
+    }
+}

--- a/ryoku/shell/quickshell/shell/modules/osd/KeyboardOsdWindow.qml
+++ b/ryoku/shell/quickshell/shell/modules/osd/KeyboardOsdWindow.qml
@@ -1,0 +1,121 @@
+import QtQuick
+import Quickshell
+import Quickshell.Wayland
+import shell.services
+import Ryoku.Ui.Singletons
+import "../../components"
+
+PanelWindow {
+    id: win
+
+    required property var modelData
+
+    readonly property real osdScale: 0.9
+
+    readonly property real us: Tokens.uiScaleFor(
+        modelData ? modelData.name : ""
+    )
+
+    readonly property real pad: 20 * us
+    readonly property real slide: 14 * us
+
+    property bool showing: false
+    property real prog: showing ? 1 : 0
+
+    Behavior on prog {
+        NumberAnimation {
+            duration: Motion.effects
+            easing.type: Easing.OutCubic
+        }
+    }
+
+    screen: modelData
+
+    visible: prog > 0.01 || showing
+
+    color: "transparent"
+
+    exclusionMode: ExclusionMode.Normal
+    exclusiveZone: 0
+
+    WlrLayershell.layer: WlrLayer.Overlay
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
+    WlrLayershell.namespace: "ryoku-keyboard-osd"
+
+    anchors.top: true
+    anchors.left: true
+    anchors.right: true
+
+    margins.top: 24 * us
+
+    implicitHeight: box.height + slide
+
+    Rectangle {
+        id: box
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.bottom: parent.bottom
+
+        width: content.implicitWidth + pad * 2
+        height: content.implicitHeight + pad - 4
+
+        radius: Theme.radiusWindow
+
+        color: Theme.surface
+        border.width: Theme.borderWidth
+        border.color: Theme.outline
+
+        opacity: Theme.windowOpacity * win.prog
+
+        antialiasing: true
+
+        transformOrigin: Item.Bottom
+
+        transform: [
+            Translate {
+                y: -win.prog * win.slide
+            },
+            Scale {
+                origin.x: box.width / 2
+                origin.y: box.height
+                xScale: win.osdScale
+                yScale: win.osdScale
+            }
+        ]
+
+        KeyboardOsd {
+            id: content
+
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            anchors.left: parent.left
+            anchors.right: parent.right
+
+            anchors.leftMargin: win.pad
+            anchors.rightMargin: win.pad
+
+            us: win.us
+        }
+    }
+
+    mask: Region {}
+
+    Timer {
+        id: hideTimer
+
+        interval: Motion.osdHide
+
+        onTriggered: {
+            win.showing = false
+        }
+    }
+
+    Connections {
+        target: KeyboardLayout
+
+        function onSignatureChanged() {
+            win.showing = true
+            hideTimer.restart()
+        }
+    }
+}

--- a/ryoku/shell/quickshell/shell/services/KeyboardLayout.qml
+++ b/ryoku/shell/quickshell/shell/services/KeyboardLayout.qml
@@ -1,0 +1,46 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Hyprland
+
+Item {
+    id: root
+
+    visible: false
+
+    property string layout: ""
+    property string variant: ""
+    property string lastEvent: ""
+
+    readonly property string signature: layout + (variant ? ":" + variant : "")
+
+    Connections {
+        target: Hyprland
+
+        function onRawEvent(event) {
+            if (event.name !== "activelayout")
+                return
+
+            root.lastEvent = event.data || ""
+
+            const parts = (event.data || "").split(",")
+
+            if (parts.length >= 2) {
+                root.layout = parts[0].trim()
+                root.variant = parts.slice(1).join(",").trim()
+
+                console.log(
+                    "[KeyboardLayout] layout:",
+                    root.layout,
+                    "variant:",
+                    root.variant
+                )
+            }
+        }
+    }
+
+    Component.onCompleted: {
+        console.log("[KeyboardLayout] service loaded")
+    }
+}

--- a/ryoku/shell/quickshell/shell/shell.qml
+++ b/ryoku/shell/quickshell/shell/shell.qml
@@ -54,7 +54,7 @@ ShellRoot {
     // Construct the shared services (ShellState's per-monitor state now, heavier
     // providers as surfaces migrate) at load rather than on the first keybind.
     ServiceLoader {
-        services: [ShellState, ScreenTime, Keypresses]
+        services: [ShellState, ScreenTime, Keypresses, KeyboardLayout]
     }
 
     readonly property string reloadStatePath: (Quickshell.env("XDG_RUNTIME_DIR") || "/tmp") + "/ryoku-reload-cover.json"
@@ -239,6 +239,9 @@ ShellRoot {
             OsdWindow {
                 modelData: perScreen.modelData
                 kind: "brightness"
+            }
+            KeyboardOsdWindow {
+                modelData: perScreen.modelData
             }
             NotificationPopups {
                 modelData: perScreen.modelData


### PR DESCRIPTION
## What changed

Added keyboard layout OSD and Widget.
Accessibility feature that tells you when you change keyboard layouts.

Should be enabled by default once you install ryoku.
You can disable the widget and change it's settings the same way other widgets do.

## Area

ryoku

## How it was tested

- Tested on main computer in unstable-dev
- Widget can be enabled/disabled and messed in with in bar studio
- Works just like any other widget works

Basically: works just fine and doesn't interfere with other widgets.

## Checklist

- [x] One logical change, with a clear `[area] scope: summary` commit subject.
- [ ] Matching `CHANGELOG.md` updated in the area I touched.
- [x] The git hooks pass locally; I did not use `--no-verify`.
- [x] Lua parses (`luac -p`), shell scripts pass `bash -n`, and QML passes
      `qmllint` where applicable.
- [x] No duplicated config, no dead code, no commented-out code, no em-dash.
- [ ] Docs updated if behavior or layout changed.