### PR TITLE
[ryoku] fix for keyboard layout service and shell studio now saves widget

### DIFF
--- a/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/Theme.qml
+++ b/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/Theme.qml
@@ -2556,6 +2556,7 @@ Item {
     onBarTemperatureSourceChanged: if (_widgetsLoaded) saveWidgets()
     onModBatteryChanged:       if (_widgetsLoaded) saveWidgets()
     onBarShadowEnabledChanged: if (_widgetsLoaded) saveWidgets()
+    onModLayoutChanged:        if (_widgetsLoaded) saveWidgets()
     onBarFrostEnabledChanged:  if (_widgetsLoaded) saveWidgets()
     onBarAutoHideChanged:      if (_widgetsLoaded) saveWidgets()
     onBarGapTopChanged:        if (_widgetsLoaded) saveWidgets()

--- a/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/controlcenter/routes/AppearanceRoute.qml
+++ b/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/controlcenter/routes/AppearanceRoute.qml
@@ -36,8 +36,13 @@ Item {
         return (page.root && prop !== "") ? page.root[prop] === true : false
     }
     function toggleMod(prop) {
-        if (page.root && prop !== "" && page.root[prop] !== undefined)
-            page.root[prop] = !page.root[prop]
+        if (!page.root || prop === "" || page.root[prop] === undefined)
+            return
+
+        page.root[prop] = !page.root[prop]
+
+        if (page.root.saveWidgets)
+            page.root.saveWidgets()
     }
 
     // ── density (compact) - drive whichever mechanism the live Theme consumes ──

--- a/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/modules/LayoutWidget.qml
+++ b/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/modules/LayoutWidget.qml
@@ -22,7 +22,7 @@ Item {
 
     readonly property string tooltipText: "Keyboard layout · " + rootMod.layout
 
-    visible: implicitWidth > 0.5
+    visible: root.modLayout && implicitWidth > 0.5
     implicitWidth: root.modLayout ? row.implicitWidth + 18 : 0
     implicitHeight: 28
     opacity: root.modLayout ? 1 : 0

--- a/ryoku/shell/quickshell/shell/services/qmldir
+++ b/ryoku/shell/quickshell/shell/services/qmldir
@@ -35,6 +35,7 @@ singleton Events Events.qml
 singleton Holidays Holidays.qml
 singleton Flags Flags.qml
 singleton Keyring Keyring.qml
+singleton KeyboardLayout KeyboardLayout.qml
 singleton OsdFeed OsdFeed.qml
 singleton Polkit Polkit.qml
 singleton PowerProfiles PowerProfiles.qml


### PR DESCRIPTION
## What changed

qmldir got reset locally
this commit fixes the keyboard layout widget not being saved and service not being present in qmldir

## Area

ryoku

## How it was tested

tested on main computer. parses and works.

## Checklist

- [x] One logical change, with a clear `[area] scope: summary` commit subject.
- [ ] Matching `CHANGELOG.md` updated in the area I touched.
- [x] The git hooks pass locally; I did not use `--no-verify`.
- [x] Lua parses (`luac -p`), shell scripts pass `bash -n`, and QML passes
      `qmllint` where applicable.
- [x] No duplicated config, no dead code, no commented-out code, no em-dash.
- [ ] Docs updated if behavior or layout changed.
