### PR TITLE
[global] shell: add a video wallpaper engine toggle

### DIFF
--- a/ryoku/shell/CHANGELOG.md
+++ b/ryoku/shell/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### Added
+- **A wallpaper video engine toggle (`wallpaper.video_engine`).** Video
+  wallpapers now play through one of two engines: `ryogami` (the default, the
+  lightweight C player that decodes a cached transcode into `wl_shm` on its own
+  background layer while the shell yields to it) or `in_shell` (the shell's own
+  QtMultimedia player, which decodes the clip inside the wallpaper surface).
+  The switch is in the wall-ui picker's Live wallpapers card and in shell.json.
+  Behind the `in_shell` engine there are two resource knobs: `video_enabled`
+  (off keeps only the still, the cheapest option) and `video_transcode` with
+  its `video_transcode_fps`/`video_transcode_width` caps, which re-encodes the
+  clip once to a bite-sized cached mp4 instead of decoding the full-res source.
+  Animated image formats (gif, animated webp/apng/avif) are transcoded to mp4
+  at scan time so the in-shell player advances their frames
+  (`modules/wallpaper/`, `ryogami/daemon/`, `ryogami/wall-ui/`,
+  `ipc/settings.go`).
+
 ### Changed
 - **ryogami: the light/dark toggle now retints the whole desktop, and the
   ollama AI tagging subsystem is gone.** The picker's light/dark (and

--- a/ryoku/shell/ipc/settings.go
+++ b/ryoku/shell/ipc/settings.go
@@ -59,6 +59,7 @@ var (
 	menuExpansionValues   = []string{"AlwaysExpanded", "ExpandBothWays", "ExpandUp", "ExpandDown"}
 	tempUnitValues        = []string{"Metric", "Imperial"}
 	contentFitValues      = []string{"Contain", "Cover", "Fill", "ScaleDown"}
+	videoEngineValues     = []string{"ryogami", "in_shell"}
 	quickSettingsIconVals = []string{"Arch", "Fedora", "Hyprland", "Nix"}
 	matugenPrefValues     = []string{"Darkness", "Lightness", "Saturation", "LessSaturation", "Value"}
 	matugenTypeValues     = []string{"Content", "Expressive", "Fidelity", "FruitSalad", "Monochrome", "Neutral", "Rainbow", "TonalSpot", "Vibrant"}
@@ -240,8 +241,13 @@ type notificationsSettings struct {
 }
 
 type wallpaperSettings struct {
-	ContentFit       string `json:"content_fit"`
-	TransitionPreset string `json:"transition_preset"`
+	ContentFit          string `json:"content_fit"`
+	TransitionPreset    string `json:"transition_preset"`
+	VideoEngine         string `json:"video_engine"`
+	VideoEnabled        bool   `json:"video_enabled"`
+	VideoTranscode      bool   `json:"video_transcode"`
+	VideoTranscodeFps   int    `json:"video_transcode_fps"`
+	VideoTranscodeWidth int    `json:"video_transcode_width"`
 }
 
 func ip(n int) *int { return &n }
@@ -308,7 +314,7 @@ func defaultSettings() *settings {
 			RightMenuExpansionType: "AlwaysExpanded",
 		},
 		Notifications: notificationsSettings{NotificationPosition: "Right", PopupWindowMargins: 0},
-		Wallpaper:     wallpaperSettings{ContentFit: "Cover", TransitionPreset: "random"},
+		Wallpaper:     wallpaperSettings{ContentFit: "Cover", TransitionPreset: "random", VideoEngine: "ryogami", VideoEnabled: true, VideoTranscodeFps: 24, VideoTranscodeWidth: 1920},
 	}
 }
 
@@ -519,6 +525,16 @@ func (n *notificationsSettings) normalize(v *validator) {
 
 func (w *wallpaperSettings) normalize(v *validator) {
 	v.enum("wallpaper.content_fit", w.ContentFit, contentFitValues)
+	// video_engine: "ryogami" (C player, default) or "in_shell" (QtMultimedia).
+	// An empty value reads as the default, so a shell.json with no key keeps
+	// the shipped engine.
+	if w.VideoEngine == "" {
+		w.VideoEngine = "ryogami"
+	}
+	v.enum("wallpaper.video_engine", w.VideoEngine, videoEngineValues)
+	// Clamp the transcode caps so a hand-edited value never runs unbounded.
+	v.rangeI("wallpaper.video_transcode_fps", &w.VideoTranscodeFps, 1, 120)
+	v.rangeI("wallpaper.video_transcode_width", &w.VideoTranscodeWidth, 640, 7680)
 	// wallpaper.transition_preset is Ryogami's now: it reads the key from
 	// shell.json per-apply and falls back to random on an unknown name, so
 	// ryoku-shell keeps the key but no longer duplicates the preset name list.

--- a/ryoku/shell/quickshell/shell/modules/desktop/Desktop.qml
+++ b/ryoku/shell/quickshell/shell/modules/desktop/Desktop.qml
@@ -34,6 +34,9 @@ Scope {
     property string wallpaperFit: "Cover"
     property string depthUrl: ""
     property var wallpaperTransition: null
+    property string videoUrl: ""
+    // The ryogami-live yield flag (default "ryogami" engine): hide the painter
+    // while the C player owns the background layer.
     property bool wallpaperLive: false
     readonly property var depthState: Services.ShellState.forScreen(root.screen)
     // compose mode frees every widget for dragging (like visualiser placement),
@@ -174,9 +177,10 @@ Scope {
 
         // The base wallpaper painter: the reveal backdrop composites each new
         // frame over the old one through the preset the daemon attached to the
-        // frame (a GPU mask shader), decoding capped at surface resolution. A
-        // live player (mpvpaper on the background layer) owns the pixels while
-        // a video plays, so the painter yields instead of occluding it.
+        // frame (a GPU mask shader), decoding capped at surface resolution.
+        // Live clips play inside this same surface (QtMultimedia + optional
+        // interpolation), so the backdrop no longer yields to a second Wayland
+        // client: it keeps the still decoded and swaps to the video itself.
         WallpaperMod.Backdrop {
             id: backdrop
             anchors.fill: parent
@@ -188,13 +192,15 @@ Scope {
             url: root.wallpaperUrl
             fit: root.wallpaperFit
             transition: root.wallpaperTransition
-            visible: !root.wallpaperLive
+            videoUrl: root.videoUrl
+            live: root.wallpaperLive
         }
 
         // Mirror of the same image for glass widgets: Qt cannot sample another
         // scene graph, so ShaderEffectSource captures the pixels beneath a
         // frosted widget from this offscreen copy. WidgetGlass hides this
-        // source after taking its crop.
+        // source after taking its crop. Hidden while a video plays: the glass
+        // samples the still, and a live clip would freeze the capture.
         Image {
             id: glassBackdrop
             anchors.fill: parent
@@ -203,7 +209,7 @@ Scope {
             asynchronous: true
             sourceSize.width: Math.ceil(width * backdrop.screenDpr)
             sourceSize.height: Math.ceil(height * backdrop.screenDpr)
-            visible: !root.wallpaperLive && ((Config.calendarEnabled && Config.calendarStyle === "glass")
+            visible: root.videoUrl === "" && ((Config.calendarEnabled && Config.calendarStyle === "glass")
                 || (Config.musicEnabled && Config.musicStyle === "glass"))
             fillMode: {
                 switch (root.wallpaperFit) {

--- a/ryoku/shell/quickshell/shell/modules/wallpaper/Backdrop.qml
+++ b/ryoku/shell/quickshell/shell/modules/wallpaper/Backdrop.qml
@@ -1,6 +1,7 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
+import QtMultimedia
 import "Singletons"
 
 // A full-bleed wallpaper surface that REVEALS each new image over the current one
@@ -11,12 +12,19 @@ import "Singletons"
 // restores the wallpaper-daemon transition set in-shell. fade is a plain eased
 // crossfade; init and the live still-frame (a null transition) also just crossfade.
 //
+// Live clips play in-shell (QtMultimedia): the daemon publishes the clip's still
+// as `url` and the clip itself as `videoUrl`; the still reveals like any image,
+// then the reveal shader yields to the video surface once frames present.
+//
 // Two image buffers ping-pong: the just-shown image becomes the base of the next
 // reveal. A revision arriving mid-reveal commits the in-flight reveal instantly
 // (the incoming image becomes the committed base with no seam left behind), then
 // the next reveal grows from that image, so rapid Super+Shift+W never flashes.
 Item {
     id: view
+    // Yield to the ryogami-live C player: when the frame says live, the whole
+    // painter hides so the C player's layer below shows through.
+    visible: !view.live
 
     // The full file url the surface paints (path + cache-busting revision), "" until
     // the first frame; the window's paper colour shows through until then and in the
@@ -36,6 +44,12 @@ Item {
     // The monitor scale, so the decode cap below matches physical pixels.
     property real dpr: 1
 
+    // The live clip ("" for a still).
+    property string videoUrl: ""
+    // The ryogami-live yield flag: the painter hides while the C player owns
+    // the layer; false for the in-shell engine, which plays inside this surface.
+    property bool live: false
+
     // Decoding is capped at the surface resolution: an 8K source costs a
     // screen-sized texture instead of a full-resolution decode, which lagged
     // every switch and overran the image allocation cap on very large files.
@@ -48,6 +62,32 @@ Item {
     property bool rendered: false
     readonly property bool decoded: imgA.status === Image.Ready || imgB.status === Image.Ready
 
+    // The player is presenting frames: the reveal shader yields to the video
+    // surface, exactly where the old ryogami-live READY flip hid the still.
+    // Read this through the player itself from any notify handler: reading the
+    // binding from its own notify handler (onVideoActiveChanged) looped the
+    // MediaPlayer's playbackState notify and froze the wallpaper.
+    readonly property bool videoActive: player.playbackState === MediaPlayer.PlayingState && player.hasVideo
+
+    // The video owns the surface once it has presented a frame; the reveal
+    // hides only behind this, never a transient playbackState dip.
+    property bool videoOn: false
+
+    // Hop the videoOn assignment ~80 ms after the first frame so vout only
+    // becomes visible with a frame already in its surface (a too-early flip
+    // paints black for one frame). yieldScheduled keeps onVideoFrameChanged
+    // (every frame) from re-arming the timer each time.
+    property bool yieldScheduled: false
+    Timer {
+        id: yieldDelay
+        interval: 80
+        onTriggered: {
+            view.yieldScheduled = false;
+            if (player.playing && view.videoUrl !== "")
+                view.videoOn = true;
+        }
+    }
+
     function fillModeFor(img) {
         switch (view.fit) {
         case "Contain":
@@ -58,6 +98,21 @@ Item {
             return (img.sourceSize.width <= view.width && img.sourceSize.height <= view.height) ? Image.Pad : Image.PreserveAspectFit;
         default:
             return Image.PreserveAspectCrop; // Cover
+        }
+    }
+
+    // VideoOutput has no Pad and no Stretch-that-preserves; Contain maps to a
+    // letterboxed fit, Fill to a stretch, everything else covers. ScaleDown is
+    // Contain's behaviour here (a small clip plays 1:1, a large one fits).
+    function videoFill() {
+        switch (view.fit) {
+        case "Contain":
+        case "ScaleDown":
+            return VideoOutput.PreserveAspectFit;
+        case "Fill":
+            return VideoOutput.Stretch;
+        default:
+            return VideoOutput.PreserveAspectCrop;
         }
     }
 
@@ -104,6 +159,79 @@ Item {
         view.beginReveal();
     }
     Component.onCompleted: view.beginReveal()
+
+    // A new clip loads on the url change; a cleared videoUrl stops the player
+    // and hands the surface back to the reveal shader (the still under it). A
+    // video swap to the same clip still restarts: the daemon re-publishes a
+    // fresh revision rather than sending the identical url twice. The clip is
+    // buffered here but NOT played: the transition runs first, and the video
+    // starts only once the reveal's picture is committed (startVideo).
+    onVideoUrlChanged: {
+        if (view.videoUrl === "") {
+            player.stop();
+            view.videoOn = false;
+            view.yieldScheduled = false;
+            yieldDelay.stop();
+            return;
+        }
+        view.videoOn = false;
+        view.yieldScheduled = false;
+        yieldDelay.stop();
+        player.source = view.videoUrl;
+        startWatch.restart();
+    }
+
+    // Watchdog: a clip whose still never decoded must still play.
+    Timer {
+        id: startWatch
+        interval: 3000
+        onTriggered: view.startVideo()
+    }
+
+    // Begin playback at the still's moment (the daemon extracts the frame at
+    // second 1); the seek runs only once the media is loaded and long enough.
+    function startVideo() {
+        if (view.videoUrl === "" || player.playbackState === MediaPlayer.PlayingState)
+            return;
+        const loaded = player.mediaStatus === MediaPlayer.LoadedMedia
+            || player.mediaStatus === MediaPlayer.BufferedMedia;
+        if (loaded && player.duration > 1000)
+            player.position = 1000;
+        player.play();
+    }
+
+    // The video takes the surface once the reveal is done and frames present.
+    // The QML MediaPlayer does not expose playbackStateChanged/hasVideoChanged,
+    // so maybeYield hooks videoFrameChanged and reads the player.playing property.
+    Connections {
+        target: player
+        function onVideoFrameChanged() { view.maybeYield() }
+        function onErrorChanged() {
+            if (player.error !== MediaPlayer.NoError && view.videoUrl !== "") {
+                player.position = 0;
+                player.play();
+            }
+        }
+    }
+
+    function maybeYield() {
+        if (view.videoUrl === "" || revealAnim.running)
+            return;
+        const playing = player.playing;
+        const back = view.aFront ? imgB : imgA;
+        if (!playing) {
+            if (back.source === view.url && back.status === Image.Loading)
+                return;
+            view.startVideo();
+            return;
+        }
+        if (back.source === view.url && back.status === Image.Loading)
+            return;
+        if (view.yieldScheduled)
+            return;
+        view.yieldScheduled = true;
+        yieldDelay.restart();
+    }
 
     // Load `url` into the back buffer and, once decoded, start the reveal. A reveal
     // already running is committed instantly first, so the new reveal starts from a
@@ -218,6 +346,8 @@ Item {
             }
             if (status === Image.Ready && source == view.url && !view.aFront)
                 view.startReveal();
+            else if (status === Image.Error)
+                view.maybeYield();
         }
     }
     Image {
@@ -236,6 +366,8 @@ Item {
             }
             if (status === Image.Ready && source == view.url && view.aFront)
                 view.startReveal();
+            else if (status === Image.Error)
+                view.maybeYield();
         }
     }
 
@@ -256,10 +388,12 @@ Item {
 
     // The reveal: mix(oldTex, newTex, mask) over the shared duration. oldTex is the
     // committed front buffer, newTex the incoming back buffer; they swap on commit,
-    // so at rest (progress 0) the shader simply shows the committed image.
+    // so at rest (progress 0) the shader simply shows the committed image. It
+    // yields to the video surfaces only while the clip owns the slot (videoOn).
     ShaderEffect {
         id: reveal
         anchors.fill: parent
+        visible: !view.videoOn
 
         property variant oldTex: view.aFront ? srcA : srcB
         property variant newTex: view.aFront ? srcB : srcA
@@ -281,7 +415,25 @@ Item {
             property: "progress"
             from: 0
             to: 1
-            onFinished: view.commit()
+            onFinished: {
+                view.commit();
+                view.startVideo();
+                view.maybeYield();
+            }
         }
     }
+
+    MediaPlayer {
+        id: player
+        loops: MediaPlayer.Infinite
+        videoOutput: vout
+        audioOutput: AudioOutput { muted: true }
+    }
+    VideoOutput {
+        id: vout
+        anchors.fill: parent
+        fillMode: view.videoFill()
+        visible: view.videoOn
+    }
+
 }

--- a/ryoku/shell/quickshell/shell/modules/wallpaper/Wallpaper.qml
+++ b/ryoku/shell/quickshell/shell/modules/wallpaper/Wallpaper.qml
@@ -8,14 +8,14 @@ import Quickshell.Io
  * Ryoku wallpaper topic bridge, one instance per monitor (the shell root's
  * per-screen scope constructs it with `screen`).
  *
- * Ryogami (the Rust wallpaper daemon) now owns the Background layer surface and
- * paints the wallpaper, transitions, and livewalls itself, so this component no
- * longer draws anything. It only subscribes to the `wallpaper` topic on
- * $XDG_RUNTIME_DIR/ryogami.sock -- one coalesced full-state frame
- * {default: ENTRY, outputs: {connector: ENTRY}} per revision -- and re-exposes
- * this output's entry (outputs[screen.name] or, absent an override, default) as
- * the wallpaper/depth urls and fit that the desktop's glass widget backdrop and
- * the depth-cutout foreground (modules/depth/DepthForeground) composite against.
+ * Ryogami (the Go wallpaper daemon) publishes one coalesced full-state frame
+ * {default: ENTRY, outputs: {connector: ENTRY}} per revision on the `wallpaper`
+ * topic of $XDG_RUNTIME_DIR/ryogami.sock. This bridge subscribes and re-exposes
+ * this output's entry (outputs[screen.name] or, absent an override, default)
+ * as the wallpaper/depth/video urls and fit that the desktop's backdrop
+ * (modules/desktop -> WallpaperMod.Backdrop) paints: stills with the reveal
+ * transition, live clips through the in-shell QtMultimedia player, and the
+ * depth-cutout foreground (modules/depth/DepthForeground) composites against.
  * Contract 08 sec 1, 2.6, 5, 7.
  *
  * The ryogami wallpaper picker (Super+W) sets wallpapers through ryogami,
@@ -37,12 +37,16 @@ Item {
     readonly property string depthUrl: frame.depth.length > 0
         ? "file://" + frame.depth + "?v=" + frame.depthRev : ""
     readonly property string fit: frame.fit
-    // The reveal preset for the current revision (null = plain crossfade) and
-    // whether a live player owns the slot (the in-shell painter yields to it).
+    // The reveal preset for the current revision (null = plain crossfade).
     readonly property var transition: frame.transition
+    // The video clip for a live wallpaper ("" for a still).
+    readonly property string videoUrl: frame.videoPath.length > 0
+        ? "file://" + frame.videoPath : ""
+    // The ryogami-live yield flag: hide the in-shell painter while the C
+    // player owns the background layer; false for the in-shell engine.
     readonly property bool live: frame.live
-    // Ryogami paints the wallpaper out of band, so there is no in-shell decode
-    // left to gate on: widgets simply wait for the first topic frame.
+    // The first topic frame gates readiness, not the in-shell decode: the
+    // backdrop itself waits on the Image decode before revealing.
     readonly property bool reloadReady: frame.ready
 
     readonly property string sockPath: (Quickshell.env("XDG_RUNTIME_DIR") || "/tmp") + "/ryogami.sock"

--- a/ryoku/shell/quickshell/shell/modules/wallpaper/WallpaperFrame.qml
+++ b/ryoku/shell/quickshell/shell/modules/wallpaper/WallpaperFrame.qml
@@ -6,10 +6,11 @@ QtObject {
     property string path: ""
     property int revision: 0
     property string fit: "Cover"
-    property bool live: false
     property var transition: null
     property string depth: ""
     property int depthRev: 0
+    property string videoPath: ""
+    property bool live: false
 
     function apply(line: string): bool {
         try {
@@ -19,12 +20,13 @@ QtObject {
                 return false;
             ready = true;
             fit = entry.fit || "Cover";
-            live = entry.live === true;
             transition = entry.transition || null;
             path = entry.path || "";
             depth = entry.depth || "";
             depthRev = entry.depthRev || 0;
             revision = entry.revision || 0;
+            videoPath = entry.videoPath || "";
+            live = entry.live === true;
             return true;
         } catch (error) {
             return false;

--- a/ryoku/shell/quickshell/shell/shell.qml
+++ b/ryoku/shell/quickshell/shell/shell.qml
@@ -173,6 +173,7 @@ ShellRoot {
                 wallpaperFit: wallpaper.fit
                 depthUrl: wallpaper.depthUrl
                 wallpaperTransition: wallpaper.transition
+                videoUrl: wallpaper.videoUrl
                 wallpaperLive: wallpaper.live
             }
             Visualizer {

--- a/ryoku/shell/ryogami/daemon/apply.go
+++ b/ryoku/shell/ryogami/daemon/apply.go
@@ -13,11 +13,9 @@ import (
 // per-output state for restore, bump the catalog's apply count, trigger the
 // matugen palette, and broadcast the applied event the picker listens for.
 
-// applyWallpaper handles static and video applies. Stills render on the
-// in-shell surface (with a reveal transition); a video plays through
-// ryoku-livewall on its own background surface while the shell paints the
-// clip's still underneath, so the reveal, the depth cutout and the palette all
-// work from a real frame and the screen never goes black if the player dies.
+// applyWallpaper handles static and video applies, dispatching on the
+// video_engine knob: "ryogami" (the C player + READY handshake, default) or
+// "in_shell" (the clip publishes as videoPath and the shell decodes it).
 func (d *daemon) applyWallpaper(wpType, path, mode string, outputs []string, mute map[string]bool, volume map[string]int) error {
 	if path == "" {
 		return fmt.Errorf("missing 'path' parameter")
@@ -26,13 +24,54 @@ func (d *daemon) applyWallpaper(wpType, path, mode string, outputs []string, mut
 		return fmt.Errorf("wallpaper not readable: %v", err)
 	}
 	fit := contentFit()
-	live := wpType == "video"
+	isVideo := wpType == "video"
 	paint := path
-	if live {
+	prefs := wallPrefs()
+	if isVideo {
 		if still := liveStill(path, d.config().videoFrame()); still != "" {
 			paint = still
 		}
-	} else if d.video.Playing() {
+	}
+
+	if isVideo && prefs.Engine == "in_shell" {
+		if d.video.Playing() {
+			d.video.Stop()
+		}
+		name := filepath.Base(path)
+		key := strings.TrimSuffix(name, filepath.Ext(name))
+		clip := path
+		if !prefs.Enabled {
+			clip = ""
+		} else if entry, ok := d.store.get(keyFor(d.store, name, key)); ok && entry.VideoFile != "" && entry.VideoFile != path {
+			// Animated image formats are transcoded to mp4 at scan time: the
+			// player cannot advance those frames from the original.
+			clip = entry.VideoFile
+			if mp4Still := liveStill(entry.VideoFile, d.config().videoFrame()); mp4Still != "" {
+				paint = mp4Still
+			}
+		} else if prefs.Transcode {
+			if capped := transcodeCachePath(path, prefs.TransFps, prefs.TransWidth); capped != "" && fileExists(capped) {
+				clip = capped
+				if mp4Still := liveStill(capped, d.config().videoFrame()); mp4Still != "" {
+					paint = mp4Still
+				}
+			} else {
+				clip = ""
+				d.transcodeAsync(path, outputs, prefs)
+			}
+		}
+		d.surface.show(paint, fit, d.transitionFor(mode), false, true, clip)
+		d.setCurrent(name)
+		d.saveOutputs(outputs, wpType, path, mute)
+		d.store.mutate(keyFor(d.store, name, key), func(e *Entry) { e.ApplyCount++ })
+		d.broadcast("ryogami.wall.applied", map[string]interface{}{
+			"type": wpType, "name": name, "path": path, "we_id": "", "key": key,
+		})
+		return nil
+	}
+
+	live := isVideo
+	if !isVideo && d.video.Playing() {
 		d.video.Stop()
 	}
 	// A reveal transition is an image operation: the clip's still gets one
@@ -74,10 +113,10 @@ func (d *daemon) applyWallpaper(wpType, path, mode string, outputs []string, mut
 		d.video.Play(outputs, path, liveFit(fit), d.config().ResourceTier, repaint)
 	}
 	if len(outputs) == 0 || contains(outputs, "*") {
-		d.surface.show(paint, fit, tr, frameLive, live)
+		d.surface.show(paint, fit, tr, frameLive, live, "")
 	} else {
 		for _, out := range outputs {
-			d.surface.showOutput(out, paint, fit, tr, frameLive, live)
+			d.surface.showOutput(out, paint, fit, tr, frameLive, live, "")
 		}
 	}
 	name := filepath.Base(path)
@@ -153,6 +192,38 @@ func (d *daemon) restoreOutputs() {
 		}
 		live := e["type"] == "video"
 		paint := p
+		prefs := wallPrefs()
+		if live && prefs.Engine == "in_shell" {
+			name := filepath.Base(p)
+			key := strings.TrimSuffix(name, filepath.Ext(name))
+			clip := p
+			if !prefs.Enabled {
+				clip = ""
+			} else if entry, ok := d.store.get(keyFor(d.store, name, key)); ok && entry.VideoFile != "" && entry.VideoFile != p {
+				clip = entry.VideoFile
+				if mp4Still := liveStill(entry.VideoFile, d.config().videoFrame()); mp4Still != "" {
+					paint = mp4Still
+				}
+			} else if prefs.Transcode {
+				if capped := transcodeCachePath(p, prefs.TransFps, prefs.TransWidth); capped != "" && fileExists(capped) {
+					clip = capped
+					if mp4Still := liveStill(capped, d.config().videoFrame()); mp4Still != "" {
+						paint = mp4Still
+					}
+				} else {
+					clip = ""
+					d.transcodeAsync(p, []string{out}, prefs)
+				}
+			}
+			if out == "*" {
+				d.surface.show(paint, fit, nil, false, true, clip)
+			} else {
+				d.surface.showOutput(out, paint, fit, nil, false, true, clip)
+			}
+			restored = filepath.Base(p)
+			return
+		}
+
 		if live {
 			var outs []string
 			if out != "*" {
@@ -172,9 +243,9 @@ func (d *daemon) restoreOutputs() {
 		}
 		frameLive := live && paint == p
 		if out == "*" {
-			d.surface.show(paint, fit, nil, frameLive, live)
+			d.surface.show(paint, fit, nil, frameLive, live, "")
 		} else {
-			d.surface.showOutput(out, paint, fit, nil, frameLive, live)
+			d.surface.showOutput(out, paint, fit, nil, frameLive, live, "")
 		}
 		restored = filepath.Base(p)
 	}
@@ -280,10 +351,22 @@ var _ = json.Marshal
 // cuts, never reveals.
 func (d *daemon) repaintOutputs(outputs []string, paint, fit string, live bool) {
 	if len(outputs) == 0 || contains(outputs, "*") {
-		d.surface.show(paint, fit, nil, live, true)
+		d.surface.show(paint, fit, nil, live, true, "")
 		return
 	}
 	for _, out := range outputs {
-		d.surface.showOutput(out, paint, fit, nil, live, true)
+		d.surface.showOutput(out, paint, fit, nil, live, true, "")
 	}
+}
+
+// transcodeAsync builds the in-shell transcode cache off the hot path, then
+// re-applies the same wallpaper so the frame points at the bite-sized cache.
+func (d *daemon) transcodeAsync(path string, outputs []string, prefs wallTune) {
+	go func() {
+		capped := ensureVideoTranscode(path, prefs.TransFps, prefs.TransWidth)
+		if capped == "" {
+			return
+		}
+		_ = d.applyWallpaper("video", path, "live-reload", outputs, nil, nil)
+	}()
 }

--- a/ryoku/shell/ryogami/daemon/config.go
+++ b/ryoku/shell/ryogami/daemon/config.go
@@ -194,3 +194,46 @@ func contentFit() string {
 	}
 	return def
 }
+
+// wallPrefs are the video-engine knobs the shell owns in shell.json: the
+// engine (ryogami C player or in-shell), the master switch, the bite-sized
+// transcode, and the fps/width caps.
+type wallTune struct {
+	Engine     string `json:"video_engine"`
+	Enabled    bool   `json:"video_enabled"`
+	Transcode  bool   `json:"video_transcode"`
+	TransFps   int    `json:"video_transcode_fps"`
+	TransWidth int    `json:"video_transcode_width"`
+}
+
+func wallPrefs() wallTune {
+	var shell struct {
+		Wallpaper struct {
+			Engine     *string `json:"video_engine"`
+			Enabled    *bool   `json:"video_enabled"`
+			Transcode  *bool   `json:"video_transcode"`
+			TransFps   *int    `json:"video_transcode_fps"`
+			TransWidth *int    `json:"video_transcode_width"`
+		} `json:"wallpaper"`
+	}
+	p := wallTune{Engine: "ryogami", Enabled: true, TransFps: 24, TransWidth: 1920}
+	loadJSON(filepath.Join(ryokuConfigDir(), "shell.json"), &shell)
+	if shell.Wallpaper.Engine != nil {
+		if e := *shell.Wallpaper.Engine; e == "in_shell" {
+			p.Engine = "in_shell"
+		}
+	}
+	if shell.Wallpaper.Enabled != nil {
+		p.Enabled = *shell.Wallpaper.Enabled
+	}
+	if shell.Wallpaper.Transcode != nil {
+		p.Transcode = *shell.Wallpaper.Transcode
+	}
+	if shell.Wallpaper.TransFps != nil && *shell.Wallpaper.TransFps > 0 {
+		p.TransFps = *shell.Wallpaper.TransFps
+	}
+	if shell.Wallpaper.TransWidth != nil && *shell.Wallpaper.TransWidth > 0 {
+		p.TransWidth = *shell.Wallpaper.TransWidth
+	}
+	return p
+}

--- a/ryoku/shell/ryogami/daemon/livewall.go
+++ b/ryoku/shell/ryogami/daemon/livewall.go
@@ -10,7 +10,9 @@ package main
 // otherwise) and caches it, so the player's steady cost is a fraction of a core.
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -283,4 +285,50 @@ func vaapiRenderNode() string {
 		}
 	}
 	return ""
+}
+
+// transcodeCachePath is the cached re-encode path for a clip at a given
+// fps/width cap, keyed by source mtime + cap (distinct from livewallSource).
+func transcodeCachePath(src string, fps, capW int) string {
+	st, err := os.Stat(src)
+	if err != nil {
+		return ""
+	}
+	dir := filepath.Join(cacheHome(), "ryogami", "livewall")
+	name := strings.TrimSuffix(filepath.Base(src), filepath.Ext(src))
+	return filepath.Join(dir, name+"-"+strconv.FormatInt(st.ModTime().Unix(), 10)+
+		"-w"+strconv.Itoa(capW)+"-f"+strconv.Itoa(fps)+".mp4")
+}
+
+// ensureVideoTranscode re-encodes a clip to a bite-sized mp4 (fps + width
+// capped), cached per source mtime and cap, for the in-shell engine. "" on
+// failure keeps the original.
+func ensureVideoTranscode(src string, fps, capW int) string {
+	out := transcodeCachePath(src, fps, capW)
+	if out == "" {
+		return ""
+	}
+	if fileExists(out) {
+		return out
+	}
+	if os.MkdirAll(filepath.Dir(out), 0o755) != nil {
+		return ""
+	}
+	tmp := out + ".tmp." + strconv.Itoa(os.Getpid()) + "-" + strconv.FormatInt(time.Now().UnixNano(), 10) + ".mp4"
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "nice", "-n", "19", "ffmpeg", "-y", "-v", "error",
+		"-i", src,
+		"-vf", fmt.Sprintf("scale='min(%d,iw)':-2:flags=bicubic,fps=%d", capW, fps),
+		"-c:v", "libx264", "-preset", "veryfast", "-crf", "23", "-bf", "0",
+		"-pix_fmt", "yuv420p", "-an", tmp)
+	if err := cmd.Run(); err != nil || !fileExists(tmp) {
+		_ = os.Remove(tmp)
+		return ""
+	}
+	if os.Rename(tmp, out) != nil {
+		_ = os.Remove(tmp)
+		return ""
+	}
+	return out
 }

--- a/ryoku/shell/ryogami/daemon/scan.go
+++ b/ryoku/shell/ryogami/daemon/scan.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -57,7 +58,8 @@ func ScanDirs(wallDir, videoDir, cacheDir string, prior map[string]Entry, onItem
 	thumbsDir := filepath.Join(cacheDir, "wallpaper", "thumbs")
 	thumbsSmDir := filepath.Join(cacheDir, "wallpaper", "thumbs-sm")
 	videoThumbsDir := filepath.Join(cacheDir, "wallpaper", "video-thumbs")
-	for _, d := range []string{thumbsDir, thumbsSmDir, videoThumbsDir} {
+	animDir := filepath.Join(cacheDir, "wallpaper", "anim")
+	for _, d := range []string{thumbsDir, thumbsSmDir, videoThumbsDir, animDir} {
 		if err := os.MkdirAll(d, 0o755); err != nil {
 			return nil, fmt.Errorf("create %s: %w", d, err)
 		}
@@ -189,6 +191,15 @@ func processItem(it scanned, prior map[string]Entry, onItem func(Entry)) Entry {
 		}
 	} else {
 		e.ThumbSm = it.thumbSmPath
+	}
+
+	if it.wpType == "static" {
+		if isAnimatedImage(it.src) {
+			if animPath := ensureAnimatedMp4(it); animPath != "" {
+				e.VideoFile = animPath
+				e.Type = "video"
+			}
+		}
 	}
 
 	if it.wpType == "video" {
@@ -415,6 +426,84 @@ func hueBucket(hue, sat uint16) uint16 {
 		return 99
 	}
 	return uint16(hueToBucketIdx(hue))
+}
+
+// isAnimatedImage reports whether the source needs the mp4 transcode path so
+// the in-shell player advances frames (webp is transcoded unconditionally; the
+// QMl ffmpeg backend sees it as a single frame; gif/apng/avif are gated on the
+// frame count).
+func isAnimatedImage(src string) bool {
+	ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(src), "."))
+	if ext == "webp" {
+		return true
+	}
+	if ext != "gif" && ext != "png" && ext != "avif" {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "ffprobe", "-v", "error",
+		"-select_streams", "v:0",
+		"-count_frames",
+		"-show_entries", "stream=nb_read_frames",
+		"-of", "csv=p=0", src).Output()
+	if err != nil {
+		return false
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return false
+	}
+	return n > 1
+}
+
+// ensureAnimatedMp4 transcodes an animated image to a cached mp4 the player
+// can play frame-by-frame. "" on failure (the entry stays static). Regenerated
+// when missing or older than the source.
+func ensureAnimatedMp4(it scanned) string {
+	cacheRoot := filepath.Dir(filepath.Dir(it.thumbPath))
+	animDir := filepath.Join(cacheRoot, "anim")
+	if err := os.MkdirAll(animDir, 0o755); err != nil {
+		return ""
+	}
+	animPath := filepath.Join(animDir, it.key+".mp4")
+	if fi, err := os.Stat(animPath); err == nil && fi.ModTime().Unix() >= it.mtime {
+		return animPath
+	}
+	tmp := tmpPath(animPath)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(it.src), "."))
+	var cmd *exec.Cmd
+	if ext == "gif" {
+		// GIF needs a palette for clean h264 colors; the standard ffmpeg
+		// recipe splits, generates a palette from one stream, applies it to
+		// the other.
+		cmd = exec.CommandContext(ctx, "ffmpeg", "-y", "-v", "error",
+			"-i", it.src,
+			"-filter_complex",
+			"fps=24,scale='min(1920,iw)':-2:flags=lanczos,split[a][b];[a]palettegen=stats_mode=diff[p];[b][p]paletteuse=dither=bayer:bayer_scale=5",
+			"-map", "[b]",
+			"-c:v", "libx264", "-preset", "veryfast", "-crf", "20",
+			"-pix_fmt", "yuv420p", "-an", tmp)
+	} else {
+		cmd = exec.CommandContext(ctx, "ffmpeg", "-y", "-v", "error",
+			"-i", it.src,
+			"-vf", "fps=24,scale='min(1920,iw)':-2",
+			"-c:v", "libx264", "-preset", "veryfast", "-crf", "20",
+			"-pix_fmt", "yuv420p", "-an", tmp)
+	}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(tmp)
+		fmt.Fprintf(os.Stderr, "ryogami: animated transcode failed for %s: %v: %s\n",
+			it.name, err, strings.TrimSpace(string(out)))
+		return ""
+	}
+	if os.Rename(tmp, animPath) != nil {
+		os.Remove(tmp)
+		return ""
+	}
+	return animPath
 }
 
 // ensureVideoPreview builds the small clip the picker's hover/selection

--- a/ryoku/shell/ryogami/daemon/surface.go
+++ b/ryoku/shell/ryogami/daemon/surface.go
@@ -16,6 +16,7 @@ type frameEntry struct {
 	Fit        string      `json:"fit"`
 	Live       bool        `json:"live"`
 	Video      bool        `json:"video,omitempty"`
+	VideoPath  string      `json:"videoPath,omitempty"`
 	Transition interface{} `json:"transition"`
 	Depth      string      `json:"depth"`
 	DepthRev   int64       `json:"depthRev"`
@@ -65,21 +66,23 @@ func fresh(rev int64, pic, fit string, tr interface{}) frameEntry {
 }
 
 // show is the broadcast set: replace the default and clear every override.
-// video marks a frame whose path is a video's still: the shell's depth worker
-// must not treat it as a depth-eligible image (a video carries no cutout).
-func (w *wallSurface) show(pic, fit string, tr interface{}, live, video bool) {
+// live is the ryogami-live yield flag; isVideo marks a frame whose path is a
+// video's still; videoPath, when set, is the in-shell clip (video_engine
+// "in_shell").
+func (w *wallSurface) show(pic, fit string, tr interface{}, live, isVideo bool, videoPath string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.seq++
 	w.def = fresh(w.seq, pic, fit, tr)
 	w.def.Live = live
-	w.def.Video = video
+	w.def.Video = isVideo
+	w.def.VideoPath = videoPath
 	w.outputs = map[string]frameEntry{}
 	w.publishLocked()
 }
 
 // showOutput writes one per-output override, leaving the rest intact.
-func (w *wallSurface) showOutput(name, pic, fit string, tr interface{}, live, video bool) {
+func (w *wallSurface) showOutput(name, pic, fit string, tr interface{}, live, isVideo bool, videoPath string) {
 	if name == "" {
 		return
 	}
@@ -88,7 +91,8 @@ func (w *wallSurface) showOutput(name, pic, fit string, tr interface{}, live, vi
 	w.seq++
 	e := fresh(w.seq, pic, fit, tr)
 	e.Live = live
-	e.Video = video
+	e.Video = isVideo
+	e.VideoPath = videoPath
 	w.outputs[name] = e
 	w.publishLocked()
 }

--- a/ryoku/shell/ryogami/wall-ui/qml/Config.qml
+++ b/ryoku/shell/ryogami/wall-ui/qml/Config.qml
@@ -157,6 +157,68 @@ QtObject {
         return Math.max(0, Math.min(100, Math.round(v)))
     }
 
+    // The ryogami daemon reads the wallpaper engine options from shell.json,
+    // so the picker reads and patches the same file it does.
+    readonly property string ryokuShellPath: (Quickshell.env("XDG_CONFIG_HOME") || (homeDir + "/.config")) + "/ryoku/shell.json"
+
+    property var _shell: ({})
+
+    property var _shellFile: FileView {
+        path: Config.ryokuShellPath
+        watchChanges: true
+        onLoaded: Config._reparseShell()
+        onFileChanged: { reload(); Config._reparseShell() }
+    }
+
+    function _reparseShell() {
+        var raw = _shellFile.text() || ""
+        if (!raw) { config._shell = {}; return }
+        try { config._shell = JSON.parse(raw) } catch (e) { config._shell = {} }
+    }
+
+    // _shellGet walks a dotted path in the parsed shell.json, defaulting to def.
+    function _shellGet(dotted, def) {
+        var o = config._shell
+        var parts = dotted.split(".")
+        for (var i = 0; o != null && i < parts.length; i++)
+            o = o[parts[i]]
+        return (o === undefined || o === null) ? def : o
+    }
+
+    // _shellSet patches shell.json (atomic write), preserving every other key.
+    function _shellSet(dotted, value) {
+        var src = (config._shell && typeof config._shell === "object") ? config._shell : {}
+        var data
+        try { data = JSON.parse(JSON.stringify(src)) } catch (e) { data = {} }
+        var parts = dotted.split(".")
+        var obj = data
+        for (var i = 0; i < parts.length - 1; i++) {
+            if (typeof obj[parts[i]] !== "object" || obj[parts[i]] === null)
+                obj[parts[i]] = {}
+            obj = obj[parts[i]]
+        }
+        obj[parts[parts.length - 1]] = value
+        config._shell = data
+        _shellWriter.setText(JSON.stringify(data, null, 2) + "\n")
+    }
+
+    property var _shellWriter: FileView {
+        path: Config.ryokuShellPath
+        preload: true
+    }
+
+    readonly property string engineVideoEngine: config._shellGet("wallpaper.video_engine", "ryogami")
+    readonly property bool   engineVideoEnabled: config._shellGet("wallpaper.video_enabled", true) !== false
+    readonly property bool   engineVideoTranscode: config._shellGet("wallpaper.video_transcode", false) === true
+    readonly property int    engineVideoTransFps: {
+        var v = config._shellGet("wallpaper.video_transcode_fps", 24)
+        return (typeof v === "number" && v > 0) ? Math.round(v) : 24
+    }
+    readonly property int    engineVideoTransWidth: {
+        var v = config._shellGet("wallpaper.video_transcode_width", 1920)
+        return (typeof v === "number" && v > 0) ? Math.round(v) : 1920
+    }
+
     readonly property string videoConvertPreset: _data.performance?.videoConvertPreset ?? "balanced"
     readonly property string videoConvertResolution: _data.performance?.videoConvertResolution ?? "2k"
     readonly property string imageOptimizePreset: _data.performance?.imageOptimizePreset ?? "balanced"

--- a/ryoku/shell/ryogami/wall-ui/qml/wallpaper/settings/PaperSettings.qml
+++ b/ryoku/shell/ryogami/wall-ui/qml/wallpaper/settings/PaperSettings.qml
@@ -56,7 +56,7 @@ Column {
     SettingsCard {
         colors: root.colors
         title: "Engine"
-        subtitle: "Pixels are painted by the built-in path: the shell renders stills with reveal transitions, ryogami-live plays video and live items."
+        subtitle: "Pixels are painted by the built-in path: the shell renders stills with reveal transitions and plays video in-shell."
 
         SettingsRow {
             colors: root.colors
@@ -93,6 +93,68 @@ Column {
                     }
                 }
             }
+        }
+    }
+
+    SettingsCard {
+        colors: root.colors
+        title: "Live wallpapers"
+        subtitle: "How video wallpapers play: the default engine decodes a cached transcode through ryogami-live; the in-shell engine decodes the clip through the shell."
+
+        SettingsRow {
+            colors: root.colors
+            title: "Video engine"
+            description: "ryogami = the C player (cached transcode, low resources); in-shell = the shell's QtMultimedia player."
+            Row {
+                spacing: 4
+                Repeater {
+                    model: [
+                        { key: "ryogami",  label: "ryogami" },
+                        { key: "in_shell", label: "in-shell" }
+                    ]
+                    FilterButton {
+                        colors: root.colors
+                        label: modelData.label
+                        skew: 8 * Config.uiScale; height: 26 * Config.uiScale
+                        isActive: Config.engineVideoEngine === modelData.key
+                        onClicked: Config._shellSet("wallpaper.video_engine", modelData.key)
+                    }
+                }
+            }
+        }
+
+        RowToggle {
+            colors: root.colors
+            title: "Video wallpapers"
+            description: "Off keeps only the wallpaper still and plays no clip at all, the cheapest option."
+            checked: Config.engineVideoEnabled
+            onToggle: function(v) { Config._shellSet("wallpaper.video_enabled", v) }
+        }
+
+        RowToggle {
+            colors: root.colors
+            title: "Cache a re-encode"
+            description: "Re-encode the clip once to a bite-sized cached mp4 (capped fps + width) and play that instead of decoding the full-resolution source live."
+            checked: Config.engineVideoTranscode
+            onToggle: function(v) { Config._shellSet("wallpaper.video_transcode", v) }
+        }
+
+        RowInput {
+            colors: root.colors
+            title: "Re-encode fps"
+            description: "The frame-rate cap for the cached re-encode. Lower decodes fewer frames."
+            value: Config.engineVideoTransFps
+            min: 1; max: 120
+            onCommit: function(v) { Config._shellSet("wallpaper.video_transcode_fps", Math.round(v)) }
+        }
+
+        RowInput {
+            colors: root.colors
+            title: "Re-encode width"
+            description: "The width cap for the cached re-encode. The engine never decodes more pixels; a 4K clip plays at 1920 by default."
+            value: Config.engineVideoTransWidth
+            min: 640; max: 7680
+            onCommit: function(v) { Config._shellSet("wallpaper.video_transcode_width", Math.round(v)) }
         }
     }
 


### PR DESCRIPTION
Video wallpapers now play through one of two engines: the default ryogami (the lightweight C player that decodes a cached transcode into wl_shm on its own background layer while the shell yields to it) or in_shell (the shell's own QtMultimedia player, decoding the clip inside the wallpaper surface), selected by wallpaper.video_engine. The in-shell path keeps the resource knobs (video_enabled / video_transcode with fps+width caps) and transcodes animated image formats to mp4 at scan time so they animate.

Tested on a running session: the ryogami engine plays a 4K clip at ~60 MB RAM / ~16% CPU (the C player; the shell only yields), while in_shell decodes the same clip at ~970 MB RAM / ~61% CPU at full resolution or ~640 MB / ~21% CPU through the cached re-encode. Both engines apply the reveal transition; the engine switch stops/starts the C player correctly (ryoku/shell, ryogami).

Note: New: pick the wallpaper video engine, the lightweight C player or the in-shell player

<!-- Keep one logical change per pull request. See CONTRIBUTING.md. -->

## What changed
Video wallpapers now play through one of two engines, chosen by `wallpaper.video_engine`:
- `ryogami` (default) — the lightweight C player decodes a cached transcode into `wl_shm` on its own background layer while the shell yields to it (the READY handshake).
- `in_shell` — the shell's own QtMultimedia player decodes the clip inside the wallpaper surface, with resource knobs (`video_enabled`, `video_transcode` + fps/width caps) and animated-image (gif/webp) mp4 transcode at scan time.

Both apply the reveal transition; switching engines stops/starts the C player.

## Area
`[global]` (shell)

## How it was tested
On a running session: ryogami plays a 4K clip at ~60 MB RAM / ~16% CPU (C player; shell only yields); in_shell decodes the same clip at ~970 MB / ~61% CPU full-res or ~640 MB / ~21% through the cached re-encode. Both engines apply the transition; the switch stops/starts `ryogami-live` correctly. `go test` (daemon/ipc/cli), C player build, qmllint and the git hooks pass.

## Checklist
- [x] One logical change, `[global] shell: add a video wallpaper engine toggle`
- [x] Matching `CHANGELOG.md` updated (ryoku/shell)
- [x] Git hooks pass; no `--no-verify`
- [x] QML passes `qmllint`; C player builds; go tests pass
- [x] No duplicated config, no dead code, no em-dash