### PR TITLE
[ryoku] QOL changes to layout widget and better handling

### DIFF
--- a/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/modules/LayoutWidget.qml
+++ b/ryoku/shell/quickshell/shell/modules/bar/barstyles/qsbar/modules/LayoutWidget.qml
@@ -9,12 +9,16 @@ Item {
     readonly property bool iconOnly: root.iconOnly("G19")
 
     property string layout: {
-        var value = KeyboardLayout.variant || ""
+        var value = KeyboardLayout.variant || KeyboardLayout.layout || ""
         if (!value)
-            return ""
+            return "US"
 
-        var match = value.match(/\(([^)]+)\)/)
-        return match ? match[1].toUpperCase() : value.toUpperCase()
+        var match = value.match(/$([^)]+)$/)
+        if (match) {
+            var inner = match[1].trim().toUpperCase()
+            return inner.length <= 4 ? inner : inner.slice(0, 2)
+        }
+        return value.length <= 4 ? value.toUpperCase() : value.slice(0, 2).toUpperCase()
     }
 
     readonly property string layoutIcon: "keyboard"
@@ -88,12 +92,18 @@ Item {
 
         hoverEnabled: true
         cursorShape: Qt.PointingHandCursor
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
 
         onEntered: tip.show()
         onExited: tip.hide()
 
-        onClicked: {
+        onClicked: function(mouse) {
             tip.hide()
+            if (mouse.button === Qt.RightButton) {
+                Quickshell.execDetached(["hyprctl", "switchxkblayout", "all", "next"])
+            } else {
+                Quickshell.execDetached(["ryoku-shell", "hub", "open", "input"])
+            }
         }
     }
 }


### PR DESCRIPTION
## What changed

Widget now has better functionality, better handling and has click functions.
#125

## Area

ryoku

## How it was tested

Tested on main computer.
Parses, works on unstable and works better than old widget

## Checklist

- [x] One logical change, with a clear `[area] scope: summary` commit subject.
- [ ] Matching `CHANGELOG.md` updated in the area I touched.
- [x] The git hooks pass locally; I did not use `--no-verify`.
- [x] Lua parses (`luac -p`), shell scripts pass `bash -n`, and QML passes
      `qmllint` where applicable.
- [x] No duplicated config, no dead code, no commented-out code, no em-dash.
- [ ] Docs updated if behavior or layout changed.
