### PR TITLE
[ryoku] doctor: ignore Zen launcher directories

### DIFF
--- a/ryoku/cli/CHANGELOG.md
+++ b/ryoku/cli/CHANGELOG.md
@@ -99,6 +99,11 @@
   placement; `validate <dir>` checks a local tree (`plugin.go`, `main.go`).
 
 ### Fixed
+- **Doctor ignores Zen launcher-wrapper directories.** Zen installations must
+  carry Firefox's `application.ini` marker before the policy reconciler treats
+  them as an install root, so a `/usr/bin/zen-browser` wrapper no longer makes
+  doctor try to create `/usr/bin/distribution/policies.json`
+  (`internal/doctor/reconcile_zen.go`).
 - **`ryoku track` takes effect without a relogin.** The channel it persists
   to `environment.d` now wins over the live `RYOKU_CHANNEL`, which the session
   captured at login and kept reporting after a switch (`ryoku status` and the

--- a/ryoku/cli/internal/doctor/reconcile_zen.go
+++ b/ryoku/cli/internal/doctor/reconcile_zen.go
@@ -102,7 +102,7 @@ func reconcileZenInto(roots []string, checkOnly bool) recResult {
 	var present, pending, did []string
 	seen := map[string]bool{}
 	for _, root := range roots {
-		if root == "" || seen[root] || !sys.Exists(root) {
+		if root == "" || seen[root] || !sys.Exists(filepath.Join(root, "application.ini")) {
 			continue
 		}
 		seen[root] = true

--- a/ryoku/cli/internal/doctor/reconcile_zen_test.go
+++ b/ryoku/cli/internal/doctor/reconcile_zen_test.go
@@ -22,6 +22,9 @@ func TestReconcileZen(t *testing.T) {
 	}
 
 	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "application.ini"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
 	dst := filepath.Join(root, "distribution", "policies.json")
 
 	// Check-only reports the pending apply and writes nothing.
@@ -70,6 +73,21 @@ func TestReconcileZen(t *testing.T) {
 	}
 	if r := reconcileZenInto([]string{root}, false); r.status != recFixed {
 		t.Fatalf("stale rewrite: status %v, want fixed", r.status)
+	}
+}
+
+func TestReconcileZenIgnoresLauncherDirectory(t *testing.T) {
+	root := t.TempDir()
+	launcher := filepath.Join(root, "zen-browser")
+	if err := os.WriteFile(launcher, []byte("#!/bin/sh\nexec /opt/zen/zen-bin \"$@\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if r := reconcileZenInto([]string{root}, false); r.status != recOK {
+		t.Fatalf("launcher directory: status %v, want ok", r.status)
+	}
+	if _, err := os.Stat(filepath.Join(root, "distribution")); !os.IsNotExist(err) {
+		t.Fatal("launcher directory was modified as if it were a Zen install")
 	}
 }
 


### PR DESCRIPTION
## Summary

- require Firefox/Zen `application.ini` before treating a candidate directory as a Zen installation root
- prevent the `/usr/bin/zen-browser` launcher wrapper from causing writes to `/usr/bin/distribution/policies.json`
- add regression coverage and document the fix in the CLI changelog

## Testing

- `go test ./internal/doctor -run 'TestReconcileZen|TestZenPolicy' -count=1`\n- `go test ./internal/doctor/... -skip '^TestReconcileUpdateChannelNoCheckout$'`\n- `git diff --check`\n\nThe skipped test inspects the real repository checkout and expects it to be clean on `unstable-dev`, which is incompatible with running it from this feature branch.