### PR TITLE
[global] shell: add parallax layer system with recoloured backdrop

### DIFF
--- a/docs/parallax.md
+++ b/docs/parallax.md
@@ -1,0 +1,148 @@
+# Parallax
+
+A layer module for the wallpaper. The composition is a dedicated
+layer-shell surface at `WlrLayer.Background` (one `PanelWindow` per
+monitor, click-through, keyboard-less, namespace `ryoku-parallax`) that
+paints the recoloured background and drifts with the cursor; the layer
+bands render inside the desktop surface at their scene z, so layers,
+widgets and the audio visualizer really interleave on screen.
+
+Two cutout modes per wallpaper:
+
+* **Auto** - the daemon shells the standalone engine
+  (`ryoku-parallax-engine`, own venv and model cache under
+  `~/.local/state/ryoku/parallax`, no dependency on `ryoku-depth`):
+  1. `cutout` produces the subject as an alpha-matted PNG;
+  2. `inpaint` recolours the cutout's hole with the surrounding colour
+     (fill holes, close gaps, widen the rim, then one mean over the
+     surrounding ring), so a drifted subject reveals the backdrop
+     instead of its own ghost.
+* **Manual** - the user drops `layer-NN.png` files into the wallpaper's
+  folder; the daemon lists whatever it finds. No engine runs.
+
+Every artifact lives in `~/Pictures/Parallax/<stem>/`: the recoloured
+background (`background.png`), the numbered layers (`layer-NN.png`) and
+the registry (`~/Pictures/Parallax/layers.pz`, daemon-owned). The
+global knobs live in `~/.config/ryoku/parallax.json`; a cut is reused
+by mtime, so the same wallpaper is never reprocessed.
+
+## Per-layer model
+
+Each layer is an object with its own knobs, indexed by layer (0 = layer
+1, back of the scene), all writable live from the sidebar:
+
+| Knob | Default | What it does |
+|---|---|---|
+| `layerEnabled` | true | Layer visible on the desktop. |
+| `parallax` | 1.0 | Cursor strength multiplier (0..2). |
+| `depth` | 0.5 | Depth factor (0..1); deeper layers drift more. |
+| `mouseMax` | 32 | Max cursor drift in px per axis (0..96). |
+| `opacity` | 1.0 | Layer alpha (0..1). |
+| `offsetX` / `offsetY` | 0 | Manual positional offset in px. |
+| `shadow` | 0 | Drop shadow strength 0..1 (depth effect's recipe). |
+| `shadowAngle` | 90 | Shadow direction in degrees (0 = right, 90 = down), set with a draggable dial. |
+| `feather` | 0 | Edge blur 0..1 (depth effect's feather). |
+| `lift` | 0 | Subject pop 0..1 (depth effect's lift). |
+| `audioLevel` | 0 | Audio reactivity 0..1 via the shared spectrum. |
+| `animType` | none | Idle motion: none, float, pulse, scale, wiggle, rotate. |
+| `animSpeed` / `animAmplitude` | 0.5 / 10 | Animation speed (0.1..3) and amplitude (px or deg). |
+
+Global motion knobs: `mouseEnabled`, `mouseSensitivity` (0.05..2),
+`mouseRange` (0.02..1 of the drift cap), `wallpaperParallax` (0..1: the
+base drifts at this share, layers at their own knobs, so the rate
+difference is the visible parallax). Presets (`none`, `softdepth`,
+`audiopulse`, `cinematic`) tune the whole stack at once; `none` resets
+the defaults. Sliders are drag-only (the mouse wheel never changes a
+value).
+
+## Visualizer and scene order
+
+The audio visualizer draws inline inside the desktop at its scene z
+while parallax owns the background; the standalone surface hides (it
+reappears while placing). The Order panel reorders layers, active
+widgets and the visualizer with up/down arrows, persisted per wallpaper
+by the daemon (`set-scene`). The order is real: each entry's z comes
+from the scene list, so a widget or the visualizer can sit between two
+layers. Off, widget z falls back to the depth front toggle.
+
+## How the parts fit
+
+```
+ryoku-shell daemon (Go)                    shell (QML)
+-----------------------                    -----------
+parallax set-enabled / set-mode /          modules/parallax/Singletons/Config.qml
+  add-layer / remove-layer / refresh        reads parallax.json (knobs) and
+  -> parallaxWorker (coalescing)            layers.pz (registry),
+  -> auto mode:  ryoku-parallax-engine      exposes the active wallpaper's
+                   cutout + inpaint          layer urls, per-layer knobs and
+  -> manual mode: read <stem>/layer-NN.png   the scene z math
+  -> writes layers.pz                      modules/parallax/ParallaxBand.qml
+      (per-wall opt-in + layer paths)        (one layer: cursor drift, feather,
+                                              lift, angled shadow, animation,
+                                              audio reactivity)
+                                            modules/parallax/ParallaxBackground.qml
+                                              owns the WlrLayer.Background
+                                              surface (recoloured background +
+                                              drift); Desktop.qml hosts the
+                                              bands, the inline visualizer and
+                                              hides its backdrop while parallax
+                                              owns.
+```
+
+- **Engine.** `ryoku-parallax-engine` is a standalone copy of
+  `ryoku-depth` cut to subject-only. Own state dir and models, so the
+  parallax module never depends on the depth install. Commands: `check`,
+  `models`, `cutout <in> <out> [--model ID] [--alpha-matting]`,
+  `inpaint <image> <mask> <out>`, `install [model...]`, `remove <model>`.
+- **Worker.** `ipc/parallax.go` mirrors the wallpaper topic, then for
+  each opted-in wallpaper generates or reuses the layer set. Opt-in is
+  per wallpaper and persists (`ryoku-shell parallax set-enabled 1|0`);
+  `set-mode` switches auto/manual; `refresh` re-runs the worker;
+  `add-layer` / `remove-layer` manage the manual folder (the remove
+  validates the path stays inside the wallpaper's folder). A refresh
+  while a cut is running, or within ten seconds of the previous finish,
+  is a no-op. `parallax status` returns
+  `{busy, current, layers, mode, stage, percent}`.
+- **Scene.** `parallax.json` `scene` is the ordered list: `wallpaper`,
+  `layer:<i>` (1..N), `widget:<id>`, `visualizer`. Empty means the
+  program computes the default. The tab's arrows move a row over or
+  under the others; Reset returns to the default.
+- **Render.** With the module on, `Desktop.qml` hides its backdrop (the
+  parallax surface owns the background layer), hosts the bands at their
+  scene z, and draws the visualizer inline; widgets resolve their z from
+  the same list. Off, everything behaves as before.
+
+## Configuration: `~/.config/ryoku/parallax.json`
+
+Self-seeded, watched, GUI-managed (the Parallax tab in the Super+Esc
+quick-settings panel, beside the Depth tab).
+
+| Key | Default | What it is |
+|---|---|---|
+| `enabled` | `false` | Module gate: layers only render when on. |
+| `mode` | `auto` | Cutout source: `auto` or `manual`. Per-wall overrides live in `layers.pz`. |
+| `model` | `u2netp` | Subject-tier model for the standalone engine. |
+| `alphaMatting` | `false` | Alpha-matting on the subject cutout. |
+| `bands` | `1` | Fallback layer count before a wallpaper is cut. |
+| `mouseEnabled` / `mouseSensitivity` / `mouseRange` | true / 0.9 / 1.0 | Global mouse reactivity. |
+| `wallpaperParallax` | `0.5` | Wallpaper drift strength (0..1 of the cap). |
+| `parallax` [], `depth` [], `mouseMax` [], `opacity` [], `offsetX` [], `offsetY` [], `shadow` [], `shadowAngle` [], `feather` [], `lift` [], `audioLevel` [], `animType` [], `animSpeed` [], `animAmplitude` [], `layerEnabled` [] | per-layer arrays | The per-layer knobs (table above). |
+| `scene` | `[]` | Ordered scene list; `[]` = program default. |
+
+Registry: `~/Pictures/Parallax/layers.pz` (daemon-owned):
+`{walls: {<path>: {enabled, mode, scene}}, layers: {<path>:
+[{out, rev, label}...]}}`.
+
+Manual folder layout: `~/Pictures/Parallax/<stem>/layer-NN.png` where
+`<stem>` is the wallpaper's basename minus extension and `NN` is at
+least two digits, sorted ascending (lowest `NN` = back of the scene).
+
+Engine status stream: `~/.local/state/ryoku/parallax/progress`, one
+JSON document per line; the last line carries `stage: "done"` on
+success or `"cancelled"` on SIGKILL.
+
+## Delivery
+
+QML and the Go worker ship in the shell tree; the engine installs to
+`/usr/bin` next to `ryoku-depth`. `parallax.json` is self-seeded and
+`layers.pz` is daemon-owned.

--- a/ryoku/shell/CHANGELOG.md
+++ b/ryoku/shell/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Added
+- **A parallax module that cuts the wallpaper into movable layers.** A
+  standalone engine (`ryoku-parallax-engine`) cuts the subject and recolours
+  the cutout's hole with the surrounding colour, and every artifact lives in
+  the wallpaper's own folder under `~/Pictures/Parallax/`; a Parallax tab in
+  the Super+Esc quick settings cuts or lists layers per wallpaper, tunes each
+  layer (parallax speed, depth, opacity, offsets, feather, lift, shadow with
+  a draggable direction dial, audio reactivity and idle animation), and the
+  scene order editor really reorders layers, widgets and the audio visualizer
+  on screen (`ipc/parallax.go`, `scripts/ryoku-parallax-engine`,
+  `modules/parallax/`, `docs/parallax.md`).
+
 ### Fixed
 - **The Super+S chat can approve a tool.** When hermes paused on an edit or a
   command, the sidebar only showed "waiting for approval" with no way to

--- a/ryoku/shell/deploy.sh
+++ b/ryoku/shell/deploy.sh
@@ -145,6 +145,7 @@ install -m755 "$here/ipc/ryoku-shell" "$bindir/ryoku-shell"
 say "installed $bindir/ryoku-shell"
 install -m755 "$here/scripts/ryoku-reload-cover" "$bindir/ryoku-reload-cover"
 install -m755 "$here/scripts/ryoku-depth" "$bindir/ryoku-depth"
+install -m755 "$here/scripts/ryoku-parallax-engine" "$bindir/ryoku-parallax-engine"
 
 # Every hyprland leaf script the config calls by bare name (ryoku-app, the
 # ryoku-cmd-*, ...). The package ships them to /usr/bin; a checkout must put the

--- a/ryoku/shell/framebars/MenuCatalog.js
+++ b/ryoku/shell/framebars/MenuCatalog.js
@@ -25,9 +25,10 @@ const quickSettingsModules = {
     "weather": { id: "weather", label: "Weather", icon: "partly_cloudy_day", source: "QuickSettingsWeather.qml" },
     "capture": { id: "capture", label: "Capture", icon: "screenshot_region", source: "QuickSettingsCapture.qml" },
     "media": { id: "media", label: "Media", icon: "music_note", source: "QuickSettingsMedia.qml" },
-    "depth": { id: "depth", label: "Depth", icon: "layers", source: "QuickSettingsDepth.qml" }
+    "depth": { id: "depth", label: "Depth", icon: "layers", source: "QuickSettingsDepth.qml" },
+    "parallax": { id: "parallax", label: "Parallax", icon: "view_in_ar", source: "QuickSettingsParallax.qml" }
 };
-const quickSettingsDefaults = ["home", "notifications", "weather", "capture", "depth"];
+const quickSettingsDefaults = ["home", "notifications", "weather", "capture", "depth", "parallax"];
 const menus = {
     "quick-settings": { id: "quick-settings", anchor: "left", minWidth: 410, expansion: "always", widgets: ["quick-settings"], modules: quickSettingsDefaults },
     wallpaper: { id: "wallpaper", anchor: "bottom", minWidth: 1400, expansion: "always", widgets: ["theme", "wallpaper"] },

--- a/ryoku/shell/ipc/daemon.go
+++ b/ryoku/shell/ipc/daemon.go
@@ -100,45 +100,48 @@ func componentDisabled(name string) bool {
 }
 
 type daemon struct {
-	mu          sync.Mutex
-	sup         map[string]bool      // components that already have a supervisor goroutine
-	proc        map[string]*exec.Cmd // current live process per component
-	paintSig    chan struct{}        // coalescing wake for the palette/border worker
-	depthSig    chan struct{}        // coalescing wake for the depth-cutout worker
-	depthForce  atomic.Bool          // a pending forced regenerate (detail change / refresh)
-	depthGen    atomic.Bool          // a pending enable: reuse a saved cutout, else generate
-	depthBusy   atomic.Bool          // a cutout generation is in flight (for status)
-	ledsSig     chan struct{}        // coalescing wake for the OpenRGB worker
-	widgetSig   chan struct{}        // coalescing wake for the widget-occupancy gate
-	quit        chan struct{}
-	closed      bool
-	ln          net.Listener
-	lock        *os.File // exclusive single-daemon guard, held until exit
-	failMu      sync.Mutex
-	lastFail    map[string]string        // component -> last line it died with
-	voiceMu     sync.Mutex               // serializes voice (Super+`) toggles
-	voiceOn     bool                     // dictation active; guarded by voiceMu
-	prompter    *prompter                // GNOME keyring system prompter (nil when unavailable)
-	monMu       sync.Mutex               // guards activeMon
-	activeMon   string                   // focused monitor, kept warm by watchHyprland
-	monFallback func() string            // monitor source when the cache is cold; tests swap it
-	gateMu      sync.Mutex               // guards gateWant / gateWake
-	gateWant    map[string]bool          // component -> may run now (absent = yes)
-	gateWake    map[string]chan struct{} // wakes a parked supervisor when its gate opens
-	parkMu      sync.Mutex               // guards hiddenSince
-	hiddenSince map[string]time.Time     // parkable palette -> when it last went hidden (absent = shown)
-	topicsMu    sync.Mutex               // guards topics
-	topics      map[string]*stateTopic   // subsystem name -> pub/sub state topic
-	callsMu     sync.Mutex               // guards calls
-	calls       map[string]callFunc      // "topic.method" -> control handler
-	clip        *clipState               // clipboard history state (nil until started)
-	tray        *trayState               // system tray watcher/host state (nil until started)
-	ryoWallMu   sync.Mutex               // guards ryoWall
-	ryoWall     ryogamiFrame             // last wallpaper frame seen from ryogami; feeds the depth worker
-	polkit      *polkitAgent             // PolicyKit1 authentication agent (nil until started)
-	settings    *settingsStore           // shell.json store (nil until startSettings); theme apply patches through it
-	pp          *powerProfilesState      // power-profiles-daemon bus state; nil until startPowerProfiles
-	keypress    *keypressManager         // evdev key stream; opens devices only while the overlay is enabled
+	mu            sync.Mutex
+	sup           map[string]bool      // components that already have a supervisor goroutine
+	proc          map[string]*exec.Cmd // current live process per component
+	paintSig      chan struct{}        // coalescing wake for the palette/border worker
+	depthSig      chan struct{}        // coalescing wake for the depth-cutout worker
+	depthForce    atomic.Bool          // a pending forced regenerate (detail change / refresh)
+	depthGen      atomic.Bool          // a pending enable: reuse a saved cutout, else generate
+	depthBusy     atomic.Bool          // a cutout generation is in flight (for status)
+	parallaxSig   chan struct{}        // coalescing wake for the parallax worker
+	parallaxForce atomic.Bool          // a pending forced parallax regenerate
+	parallaxBusy  atomic.Bool          // a parallax cut is in flight (for status)
+	ledsSig       chan struct{}        // coalescing wake for the OpenRGB worker
+	widgetSig     chan struct{}        // coalescing wake for the widget-occupancy gate
+	quit          chan struct{}
+	closed        bool
+	ln            net.Listener
+	lock          *os.File // exclusive single-daemon guard, held until exit
+	failMu        sync.Mutex
+	lastFail      map[string]string        // component -> last line it died with
+	voiceMu       sync.Mutex               // serializes voice (Super+`) toggles
+	voiceOn       bool                     // dictation active; guarded by voiceMu
+	prompter      *prompter                // GNOME keyring system prompter (nil when unavailable)
+	monMu         sync.Mutex               // guards activeMon
+	activeMon     string                   // focused monitor, kept warm by watchHyprland
+	monFallback   func() string            // monitor source when the cache is cold; tests swap it
+	gateMu        sync.Mutex               // guards gateWant / gateWake
+	gateWant      map[string]bool          // component -> may run now (absent = yes)
+	gateWake      map[string]chan struct{} // wakes a parked supervisor when its gate opens
+	parkMu        sync.Mutex               // guards hiddenSince
+	hiddenSince   map[string]time.Time     // parkable palette -> when it last went hidden (absent = shown)
+	topicsMu      sync.Mutex               // guards topics
+	topics        map[string]*stateTopic   // subsystem name -> pub/sub state topic
+	callsMu       sync.Mutex               // guards calls
+	calls         map[string]callFunc      // "topic.method" -> control handler
+	clip          *clipState               // clipboard history state (nil until started)
+	tray          *trayState               // system tray watcher/host state (nil until started)
+	ryoWallMu     sync.Mutex               // guards ryoWall
+	ryoWall       ryogamiFrame             // last wallpaper frame seen from ryogami; feeds the depth worker
+	polkit        *polkitAgent             // PolicyKit1 authentication agent (nil until started)
+	settings      *settingsStore           // shell.json store (nil until startSettings); theme apply patches through it
+	pp            *powerProfilesState      // power-profiles-daemon bus state; nil until startPowerProfiles
+	keypress      *keypressManager         // evdev key stream; opens devices only while the overlay is enabled
 }
 
 func runDaemon() error {
@@ -192,6 +195,7 @@ func runDaemon() error {
 		proc:        map[string]*exec.Cmd{},
 		paintSig:    make(chan struct{}, 1),
 		depthSig:    make(chan struct{}, 1),
+		parallaxSig: make(chan struct{}, 1),
 		ledsSig:     make(chan struct{}, 1),
 		widgetSig:   make(chan struct{}, 1),
 		quit:        make(chan struct{}),
@@ -342,6 +346,7 @@ func (d *daemon) bootstrap() {
 	d.startUpdates()
 	go d.paintWorker()
 	go d.depthWorker()
+	go d.parallaxWorker()
 	go d.watchRyogami()
 	go d.watchMatugenKnobs()
 	go d.ledsWorker()
@@ -1013,6 +1018,53 @@ func (d *daemon) dispatch(line string) string {
 		if len(args) >= 1 && args[0] == "clear" {
 			d.depthClearCache()
 			return "ok"
+		}
+		return "ok"
+	case "parallax":
+		// set-enabled records the per-wall opt-in; set-mode switches between
+		// auto (engine-cut subject + LaMa inpaint) and manual (user-placed
+		// numbered layers); add-layer / remove-layer manage the manual
+		// folder; refresh forces a regenerate; set-scene stores the per-wall
+		// scene order; cancel kills a running cut; status reports the
+		// worker's busy flag, the layer count, the mode and the latest
+		// stage + percent. The module keeps its own file
+		// (~/Pictures/Parallax/layers.pz).
+		if len(args) >= 2 && args[0] == "set-enabled" {
+			d.parallaxSetEnabled(args[1] == "1" || args[1] == "true")
+			return "ok"
+		}
+		if len(args) >= 2 && args[0] == "set-mode" {
+			d.parallaxSetMode(parallaxMode(args[1]))
+			return "ok"
+		}
+		if len(args) >= 2 && args[0] == "add-layer" {
+			path, err := d.parallaxAddManualLayer(args[1])
+			if err != nil {
+				return "err parallax add-layer: " + err.Error()
+			}
+			return "ok " + path
+		}
+		if len(args) >= 2 && args[0] == "remove-layer" {
+			if err := d.parallaxRemoveManualLayer(args[1]); err != nil {
+				return "err parallax remove-layer: " + err.Error()
+			}
+			return "ok"
+		}
+		if len(args) >= 1 && args[0] == "refresh" {
+			d.parallaxForce.Store(true)
+			d.scheduleParallax()
+			return "ok"
+		}
+		if len(args) >= 2 && args[0] == "set-scene" {
+			d.parallaxSetScene(args[1])
+			return "ok"
+		}
+		if len(args) >= 1 && args[0] == "cancel" {
+			parallaxCancel()
+			return "ok"
+		}
+		if len(args) >= 1 && args[0] == "status" {
+			return d.parallaxStatusJSON()
 		}
 		return "ok"
 	case "theme":

--- a/ryoku/shell/ipc/parallax.go
+++ b/ryoku/shell/ipc/parallax.go
@@ -1,0 +1,666 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+// Parallax: cuts or lists the wallpaper's layers per wall (docs/parallax.md).
+// Auto shells ryoku-parallax-engine (subject + recoloured background); manual
+// lists ~/Pictures/Parallax/<stem>/layer-NN.png. The QML watches layers.pz.
+
+type parallaxMode string
+
+const (
+	parallaxModeAuto   parallaxMode = "auto"
+	parallaxModeManual parallaxMode = "manual"
+)
+
+type parallaxWall struct {
+	Enabled bool         `json:"enabled"`
+	Mode    parallaxMode `json:"mode"`
+	Scene   []string     `json:"scene,omitempty"`
+}
+
+type parallaxLayerRef struct {
+	Out   string  `json:"out"`
+	Rev   int64   `json:"rev"`
+	Label string  `json:"label,omitempty"`
+	Depth float32 `json:"depth,omitempty"`
+	Area  float32 `json:"area,omitempty"`
+}
+
+type parallaxWalls struct {
+	Walls  map[string]parallaxWall       `json:"walls"`
+	Layers map[string][]parallaxLayerRef `json:"layers"`
+}
+
+func parallaxWallsPath() string { return filepath.Join(parallaxDir(), "layers.pz") }
+
+func loadParallaxWalls() parallaxWalls {
+	w := parallaxWalls{Walls: map[string]parallaxWall{}, Layers: map[string][]parallaxLayerRef{}}
+	raw, err := os.ReadFile(parallaxWallsPath())
+	if err != nil {
+		return w
+	}
+	if json.Unmarshal(raw, &w) != nil {
+		return w
+	}
+	if w.Walls == nil {
+		w.Walls = map[string]parallaxWall{}
+	}
+	if w.Layers == nil {
+		w.Layers = map[string][]parallaxLayerRef{}
+	}
+	return w
+}
+
+func saveParallaxWalls(w parallaxWalls) {
+	if w.Walls == nil {
+		w.Walls = map[string]parallaxWall{}
+	}
+	if w.Layers == nil {
+		w.Layers = map[string][]parallaxLayerRef{}
+	}
+	_ = os.MkdirAll(filepath.Dir(parallaxWallsPath()), 0o755)
+	if b, err := json.MarshalIndent(w, "", "  "); err == nil {
+		_ = os.WriteFile(parallaxWallsPath(), b, 0o644)
+	}
+}
+
+type parallaxConfig struct {
+	mode         parallaxMode
+	model        string
+	alphaMatting bool
+}
+
+func parallaxConfigFromFile() parallaxConfig {
+	def := parallaxConfig{mode: parallaxModeAuto, model: "u2netp", alphaMatting: false}
+	dir := ryokuConfigDir()
+	if dir == "" {
+		return def
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "parallax.json"))
+	if err != nil {
+		return def
+	}
+	var m struct {
+		Mode         string `json:"mode"`
+		Model        string `json:"model"`
+		AlphaMatting bool   `json:"alphaMatting"`
+	}
+	if json.Unmarshal(b, &m) != nil {
+		return def
+	}
+	out := def
+	switch parallaxMode(m.Mode) {
+	case parallaxModeAuto, parallaxModeManual:
+		out.mode = parallaxMode(m.Mode)
+	}
+	if m.Model != "" {
+		out.model = m.Model
+	}
+	if m.AlphaMatting {
+		out.alphaMatting = true
+	}
+	return out
+}
+
+func parallaxDir() string { return filepath.Join(os.Getenv("HOME"), "Pictures", "Parallax") }
+
+// layer-01.png in the per-wallpaper folder.
+func parallaxSubjectOut(source string) string {
+	return filepath.Join(parallaxManualDir(source), "layer-01.png")
+}
+
+// background.png in the per-wallpaper folder.
+func parallaxInpaintedOut(source string) string {
+	return filepath.Join(parallaxManualDir(source), "background.png")
+}
+
+func parallaxManualDir(source string) string {
+	stem := strings.TrimSuffix(filepath.Base(source), filepath.Ext(filepath.Base(source)))
+	return filepath.Join(parallaxDir(), stem)
+}
+
+var manualLayerRe = regexp.MustCompile(`^layer-(\d{2,})\.png$`)
+
+func parallaxProgressPath() string {
+	return filepath.Join(stateDir(), "ryoku", "parallax", "progress")
+}
+
+func writeParallaxProgress(record map[string]any) {
+	path := parallaxProgressPath()
+	_ = os.MkdirAll(filepath.Dir(path), 0o755)
+	b, err := json.Marshal(record)
+	if err != nil {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_, _ = f.Write(append(b, '\n'))
+}
+
+func progressPercent(rec map[string]any) int {
+	stage, _ := rec["stage"].(string)
+	switch stage {
+	case "starting", "reading":
+		return 5
+	case "subject":
+		return 45
+	case "inpaint":
+		return 80
+	case "writing":
+		return 92
+	case "done":
+		return 100
+	case "cancelled":
+		return 100
+	default:
+		return 0
+	}
+}
+
+func progressLabel(rec map[string]any) string {
+	stage, _ := rec["stage"].(string)
+	switch stage {
+	case "starting":
+		return "starting"
+	case "reading":
+		return "reading wallpaper"
+	case "subject":
+		return "cutting subject"
+	case "inpaint":
+		return "inpainting background"
+	case "writing":
+		return "writing layer"
+	case "done":
+		return "done"
+	case "cancelled":
+		return "cancelled"
+	case "error":
+		return "error"
+	default:
+		return stage
+	}
+}
+
+func readLastParallaxProgress() (map[string]any, string, int) {
+	b, err := os.ReadFile(parallaxProgressPath())
+	if err != nil {
+		return nil, "", 0
+	}
+	var record map[string]any
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var rec map[string]any
+		if json.Unmarshal([]byte(line), &rec) != nil {
+			continue
+		}
+		record = rec
+	}
+	if record == nil {
+		return nil, "", 0
+	}
+	return record, progressLabel(record), progressPercent(record)
+}
+
+func (d *daemon) parallaxStatusJSON() string {
+	reg := loadParallaxWalls()
+	wall := d.currentWall()
+	entry, hasWall := reg.Walls[wall]
+	layers := len(reg.Layers[wall])
+	_, label, percent := readLastParallaxProgress()
+	mode := entry.Mode
+	if mode == "" {
+		mode = parallaxModeAuto
+	}
+	b, _ := json.Marshal(struct {
+		Busy    bool         `json:"busy"`
+		Current bool         `json:"current"`
+		Layers  int          `json:"layers"`
+		Mode    parallaxMode `json:"mode"`
+		Stage   string       `json:"stage"`
+		Percent int          `json:"percent"`
+	}{
+		Busy:    d.parallaxBusy.Load(),
+		Current: hasWall && entry.Enabled,
+		Layers:  layers,
+		Mode:    mode,
+		Stage:   label,
+		Percent: percent,
+	})
+	return string(b)
+}
+
+func runParallaxAuto(source string, subjectModel string, alphaMatting bool) error {
+	subjectOut := parallaxSubjectOut(source)
+	inpaintedOut := parallaxInpaintedOut(source)
+	if err := os.MkdirAll(filepath.Dir(subjectOut), 0o755); err != nil {
+		return err
+	}
+
+	cutoutArgs := []string{"cutout", source, subjectOut, "--model", subjectModel}
+	if alphaMatting {
+		cutoutArgs = append(cutoutArgs, "--alpha-matting")
+	}
+
+	if parallaxCutPID.Swap(int32(os.Getpid())) == 0 {
+		defer parallaxCutPID.Store(0)
+	}
+
+	writeParallaxProgress(map[string]any{"stage": "subject", "model": subjectModel})
+	cmd := exec.Command(parallaxEngineBin(), cutoutArgs...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = io.Copy(io.Discard, stderr)
+	}()
+	werr := cmd.Run()
+	<-done
+	if werr != nil {
+		writeParallaxProgress(map[string]any{"stage": "error", "error": werr.Error()})
+		return werr
+	}
+	if _, err := os.Stat(subjectOut); err != nil {
+		writeParallaxProgress(map[string]any{"stage": "error", "error": "subject png missing"})
+		return err
+	}
+
+	writeParallaxProgress(map[string]any{"stage": "inpaint"})
+	inpaintCmd := exec.Command(parallaxEngineBin(), "inpaint", source, subjectOut, inpaintedOut)
+	inpaintCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	inStderr, err := inpaintCmd.StderrPipe()
+	if err != nil {
+		writeParallaxProgress(map[string]any{"stage": "error", "error": err.Error()})
+		return err
+	}
+	done2 := make(chan struct{})
+	go func() {
+		defer close(done2)
+		_, _ = io.Copy(io.Discard, inStderr)
+	}()
+	werr = inpaintCmd.Run()
+	<-done2
+	if werr != nil {
+		// Inpainting failing is non-fatal: the user can still see the
+		// subject drifting over the original wallpaper (which still has
+		// the subject drawn in it). The daemon logs and the surface
+		// falls back to the original.
+		writeParallaxProgress(map[string]any{"stage": "error", "error": werr.Error(), "warning": "inpaint failed"})
+		return nil
+	}
+
+	writeParallaxProgress(map[string]any{"stage": "done", "subject": filepath.Base(subjectOut), "inpainted": filepath.Base(inpaintedOut)})
+	// Sweep mktemp leftovers from cancelled cuts.
+	for _, base := range []string{subjectOut, inpaintedOut} {
+		dir := filepath.Dir(base)
+		prefix := filepath.Base(base) + "."
+		if entries, err := os.ReadDir(dir); err == nil {
+			for _, e := range entries {
+				if !e.IsDir() && strings.HasPrefix(e.Name(), prefix) {
+					os.Remove(filepath.Join(dir, e.Name()))
+				}
+			}
+		}
+	}
+	parallaxLastFinish.Store(time.Now().Unix())
+	return nil
+}
+
+var parallaxCutPID atomic.Int32
+var parallaxLastFinish atomic.Int64
+
+func parallaxCancel() {
+	pid := int(parallaxCutPID.Load())
+	if pid <= 0 {
+		return
+	}
+	_ = syscall.Kill(-pid, syscall.SIGKILL)
+}
+
+func parallaxEngineBin() string {
+	if dir := os.Getenv("RYOKU_SHELL_DIR"); dir != "" {
+		p := filepath.Join(dir, "scripts", "ryoku-parallax-engine")
+		if isFile(p) {
+			return p
+		}
+	}
+	return "ryoku-parallax-engine"
+}
+
+func parallaxEngineAvailable() bool {
+	return exec.Command(parallaxEngineBin(), "check").Run() == nil
+}
+
+func (d *daemon) scheduleParallax() {
+	select {
+	case d.parallaxSig <- struct{}{}:
+	default:
+	}
+}
+
+func (d *daemon) parallaxWorker() {
+	for range d.parallaxSig {
+		d.reconcileParallax(d.parallaxForce.Swap(false))
+	}
+}
+
+type parallaxTarget struct {
+	slot   string
+	source string
+}
+
+func (d *daemon) parallaxTargets() []parallaxTarget {
+	f := d.wallFrame()
+	var out []parallaxTarget
+	if p := f.Default.Path; p != "" && !f.Default.Live && !f.Default.Video && !isVideo(p) && isFile(p) {
+		out = append(out, parallaxTarget{"", p})
+	}
+	for name, e := range f.Outputs {
+		if e.Path != "" && !e.Live && !e.Video && !isVideo(e.Path) && isFile(e.Path) {
+			out = append(out, parallaxTarget{name, e.Path})
+		}
+	}
+	return out
+}
+
+func (d *daemon) reconcileParallax(force bool) {
+	cfg := parallaxConfigFromFile()
+	reg := loadParallaxWalls()
+	targets := d.parallaxTargets()
+
+	if len(targets) == 0 {
+		d.parallaxBusy.Store(false)
+		return
+	}
+	_ = os.MkdirAll(parallaxDir(), 0o755)
+	changed := false
+	defer func() { d.parallaxBusy.Store(false) }()
+
+	for _, t := range targets {
+		wall, ok := reg.Walls[t.source]
+		if !ok || !wall.Enabled {
+			if _, had := reg.Layers[t.source]; had {
+				delete(reg.Layers, t.source)
+				changed = true
+			}
+			continue
+		}
+		mode := wall.Mode
+		if mode == "" {
+			mode = cfg.mode
+		}
+		layers := d.refreshWallLayers(t.source, mode, force)
+		if layers == nil {
+			continue
+		}
+		reg.Layers[t.source] = layers
+		entry := reg.Walls[t.source]
+		entry.Mode = mode
+		reg.Walls[t.source] = entry
+		changed = true
+	}
+
+	if changed {
+		saveParallaxWalls(reg)
+	}
+}
+
+func (d *daemon) refreshWallLayers(source string, mode parallaxMode, force bool) []parallaxLayerRef {
+	switch mode {
+	case parallaxModeManual:
+		return listManualLayers(source)
+	case parallaxModeAuto:
+		return d.refreshAutoLayers(source, force)
+	default:
+		return d.refreshAutoLayers(source, force)
+	}
+}
+
+func listManualLayers(source string) []parallaxLayerRef {
+	dir := parallaxManualDir(source)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return []parallaxLayerRef{}
+	}
+	type found struct {
+		idx int
+		ref parallaxLayerRef
+	}
+	var files []found
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		match := manualLayerRe.FindStringSubmatch(e.Name())
+		if match == nil {
+			continue
+		}
+		var idx int
+		_, _ = fmt.Sscanf(match[1], "%d", &idx)
+		path := filepath.Join(dir, e.Name())
+		files = append(files, found{
+			idx: idx,
+			ref: parallaxLayerRef{
+				Out:   path,
+				Rev:   fileModTime(path),
+				Label: fmt.Sprintf("Layer %d", idx),
+			},
+		})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].idx < files[j].idx })
+	layers := make([]parallaxLayerRef, 0, len(files))
+	for _, f := range files {
+		layers = append(layers, f.ref)
+	}
+	return layers
+}
+
+func (d *daemon) refreshAutoLayers(source string, force bool) []parallaxLayerRef {
+	if !parallaxEngineAvailable() {
+		return nil
+	}
+	subjectOut := parallaxSubjectOut(source)
+	inpaintedOut := parallaxInpaintedOut(source)
+
+	stem := strings.TrimSuffix(filepath.Base(source), filepath.Ext(filepath.Base(source)))
+	for _, legacy := range []string{
+		filepath.Join(parallaxDir(), stem+"-subject.png"),
+		filepath.Join(parallaxDir(), stem+"-inpainted.png"),
+	} {
+		if isFile(legacy) {
+			os.Remove(legacy)
+		}
+	}
+
+	if !force {
+		srcMod := fileModTime(source)
+		if st, err := os.Stat(subjectOut); err == nil && st.ModTime().Unix() >= srcMod {
+			return []parallaxLayerRef{{Out: subjectOut, Rev: st.ModTime().Unix(), Label: "subject"}}
+		}
+	}
+	if parallaxCutPID.Load() > 0 {
+		return nil
+	}
+	if !force {
+		const settleCutoff = int64(10)
+		last := parallaxLastFinish.Load()
+		if last > 0 && time.Now().Unix()-last < settleCutoff {
+			return nil
+		}
+	}
+	cfg := parallaxConfigFromFile()
+	d.parallaxBusy.Store(true)
+	if err := runParallaxAuto(source, cfg.model, cfg.alphaMatting); err != nil {
+		fmt.Fprintf(os.Stderr, "parallaxWorker: %v\n", err)
+		return nil
+	}
+	st, err := os.Stat(subjectOut)
+	if err != nil {
+		return nil
+	}
+	_ = inpaintedOut
+	return []parallaxLayerRef{{Out: subjectOut, Rev: st.ModTime().Unix(), Label: "subject"}}
+}
+
+func (d *daemon) parallaxSetEnabled(on bool) {
+	d.parallaxSetEnabledMode(on, "")
+}
+
+func (d *daemon) parallaxSetMode(mode parallaxMode) {
+	wall := d.currentWall()
+	if wall == "" {
+		return
+	}
+	d.parallaxSetEnabledMode(true, mode)
+}
+
+func (d *daemon) parallaxSetEnabledMode(on bool, mode parallaxMode) {
+	wall := d.currentWall()
+	if wall == "" {
+		return
+	}
+	reg := loadParallaxWalls()
+	prevEnabled := reg.Walls[wall].Enabled
+	prevLayers := len(reg.Layers[wall])
+	prevMode := reg.Walls[wall].Mode
+	if on {
+		entry := reg.Walls[wall]
+		entry.Enabled = true
+		if mode != "" {
+			entry.Mode = mode
+		} else if entry.Mode == "" {
+			entry.Mode = parallaxConfigFromFile().mode
+		}
+		reg.Walls[wall] = entry
+	} else {
+		delete(reg.Walls, wall)
+		delete(reg.Layers, wall)
+	}
+	dirty := reg.Walls[wall].Enabled != prevEnabled ||
+		len(reg.Layers[wall]) != prevLayers ||
+		reg.Walls[wall].Mode != prevMode
+	if dirty {
+		saveParallaxWalls(reg)
+	}
+	d.parallaxForce.Store(true)
+	d.scheduleParallax()
+}
+
+func (d *daemon) parallaxSetScene(body string) {
+	wall := d.currentWall()
+	if wall == "" {
+		return
+	}
+	var scene []string
+	if err := json.Unmarshal([]byte(body), &scene); err != nil {
+		return
+	}
+	reg := loadParallaxWalls()
+	entry := reg.Walls[wall]
+	entry.Enabled = entry.Enabled || len(scene) > 0
+	entry.Scene = scene
+	reg.Walls[wall] = entry
+	saveParallaxWalls(reg)
+}
+
+func (d *daemon) parallaxAddManualLayer(src string) (string, error) {
+	wall := d.currentWall()
+	if wall == "" {
+		return "", fmt.Errorf("no active wallpaper")
+	}
+	if src == "" {
+		return "", fmt.Errorf("empty source path")
+	}
+	st, err := os.Stat(src)
+	if err != nil || st.IsDir() {
+		return "", fmt.Errorf("source not a file: %s", src)
+	}
+	dir := parallaxManualDir(wall)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	next := 1
+	entries, err := os.ReadDir(dir)
+	if err == nil {
+		for _, e := range entries {
+			match := manualLayerRe.FindStringSubmatch(e.Name())
+			if match == nil {
+				continue
+			}
+			var idx int
+			_, _ = fmt.Sscanf(match[1], "%d", &idx)
+			if idx >= next {
+				next = idx + 1
+			}
+		}
+	}
+	name := fmt.Sprintf("layer-%02d.png", next)
+	dst := filepath.Join(dir, name)
+	if err := copyFile(src, dst); err != nil {
+		return "", err
+	}
+	d.parallaxForce.Store(true)
+	d.scheduleParallax()
+	return dst, nil
+}
+
+func (d *daemon) parallaxRemoveManualLayer(path string) error {
+	wall := d.currentWall()
+	if wall == "" {
+		return fmt.Errorf("no active wallpaper")
+	}
+	if path == "" {
+		return fmt.Errorf("empty path")
+	}
+	dir := parallaxManualDir(wall)
+	clean := filepath.Clean(path)
+	if !strings.HasPrefix(clean, dir+string(filepath.Separator)) {
+		return fmt.Errorf("not in wallpaper folder: %s", path)
+	}
+	if err := os.Remove(clean); err != nil {
+		return err
+	}
+	d.parallaxForce.Store(true)
+	d.scheduleParallax()
+	return nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/ryoku/shell/ipc/parallax_test.go
+++ b/ryoku/shell/ipc/parallax_test.go
@@ -1,0 +1,366 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProgressLabel(t *testing.T) {
+	cases := []struct {
+		stage string
+		want  string
+	}{
+		{"reading", "reading wallpaper"},
+		{"subject", "cutting subject"},
+		{"inpaint", "inpainting background"},
+		{"writing", "writing layer"},
+		{"done", "done"},
+		{"cancelled", "cancelled"},
+	}
+	for _, tc := range cases {
+		rec := map[string]any{"stage": tc.stage}
+		got := progressLabel(rec)
+		if got != tc.want {
+			t.Errorf("progressLabel(%q) = %q, want %q", tc.stage, got, tc.want)
+		}
+	}
+}
+
+func TestProgressPercentMidpoints(t *testing.T) {
+	for stage, want := range map[string]int{
+		"subject": 45,
+		"inpaint": 80,
+		"done":    100,
+		"writing": 92,
+	} {
+		if got := progressPercent(map[string]any{"stage": stage}); got != want {
+			t.Errorf("progressPercent(%q) = %d, want %d", stage, got, want)
+		}
+	}
+}
+
+func TestReadLastParallaxProgress(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(dir, ".local", "state"))
+
+	path := parallaxProgressPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range []map[string]any{
+		{"stage": "starting"},
+		{"stage": "subject", "model": "u2netp"},
+		{"stage": "inpaint"},
+		{"stage": "done", "subject": "wp-subject.png"},
+	} {
+		b, _ := json.Marshal(r)
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.Write(append(b, '\n')); err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+	}
+	rec, label, percent := readLastParallaxProgress()
+	if rec == nil {
+		t.Fatal("readLastParallaxProgress returned nil")
+	}
+	if got := rec["stage"]; got != "done" {
+		t.Fatalf("rec[stage] = %v, want done", got)
+	}
+	if label != "done" || percent != 100 {
+		t.Fatalf("label/percent = %q/%d, want done/100", label, percent)
+	}
+}
+
+func TestParallaxStatusJSONFields(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(dir, ".local", "state"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("PATH", t.TempDir()) // no ryoku-parallax-engine: engine reads as absent.
+
+	wall := filepath.Join(dir, "wp.png")
+	writeFile(t, wall, "png")
+	parallaxDir := filepath.Join(dir, "Pictures", "Parallax")
+	if err := os.MkdirAll(parallaxDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	l1 := filepath.Join(parallaxDir, "wp-l1.png")
+	l2 := filepath.Join(parallaxDir, "wp-l2.png")
+	writeFile(t, l1, "a")
+	writeFile(t, l2, "b")
+
+	reg := parallaxWalls{Walls: map[string]parallaxWall{}, Layers: map[string][]parallaxLayerRef{}}
+	reg.Walls[wall] = parallaxWall{Enabled: true, Mode: parallaxModeManual}
+	reg.Layers[wall] = []parallaxLayerRef{
+		{Out: l1, Rev: fileModTime(l1)},
+		{Out: l2, Rev: fileModTime(l2)},
+	}
+	saveParallaxWalls(reg)
+
+	progressFile := parallaxProgressPath()
+	if err := os.MkdirAll(filepath.Dir(progressFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, progressFile, `{"stage":"subject"}`+"\n")
+
+	d := &daemon{}
+	d.ryoWallMu.Lock()
+	d.ryoWall = ryogamiFrame{Default: ryogamiFrameEntry{Path: wall}}
+	d.ryoWallMu.Unlock()
+	d.parallaxBusy.Store(true)
+
+	body := d.parallaxStatusJSON()
+	var got map[string]any
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("status JSON: %v", err)
+	}
+	for _, k := range []string{"busy", "current", "layers", "mode", "stage", "percent"} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("status JSON missing %q; body=%s", k, body)
+		}
+	}
+	if got["busy"] != true || got["current"] != true {
+		t.Errorf("busy/current = %v/%v, want true/true", got["busy"], got["current"])
+	}
+	if got["layers"].(float64) != 2 {
+		t.Errorf("layers = %v, want 2", got["layers"])
+	}
+	if got["mode"] != "manual" {
+		t.Errorf("mode = %v, want manual", got["mode"])
+	}
+	if got["stage"] != "cutting subject" {
+		t.Errorf("stage = %v, want cutting subject", got["stage"])
+	}
+}
+
+func TestParallaxRefreshGuard(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(dir, ".local", "state"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+
+	wall := filepath.Join(dir, "wp.png")
+	writeFile(t, wall, "png")
+	reg := parallaxWalls{Walls: map[string]parallaxWall{}, Layers: map[string][]parallaxLayerRef{}}
+	reg.Walls[wall] = parallaxWall{Enabled: true, Mode: parallaxModeAuto}
+	saveParallaxWalls(reg)
+
+	parallaxCutPID.Store(98765)
+	defer parallaxCutPID.Store(0)
+	parallaxLastFinish.Store(0)
+
+	d := &daemon{}
+	d.ryoWallMu.Lock()
+	d.ryoWall = ryogamiFrame{Default: ryogamiFrameEntry{Path: wall}}
+	d.ryoWallMu.Unlock()
+
+	d.reconcileParallax(false)
+	if got := len(loadParallaxWalls().Layers[wall]); got != 0 {
+		t.Fatalf("reconcile ran with PID live; layers = %d", got)
+	}
+}
+
+func TestParallaxRefreshSettle(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(dir, ".local", "state"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+
+	wall := filepath.Join(dir, "wp.png")
+	writeFile(t, wall, "png")
+	reg := parallaxWalls{Walls: map[string]parallaxWall{}, Layers: map[string][]parallaxLayerRef{}}
+	reg.Walls[wall] = parallaxWall{Enabled: true, Mode: parallaxModeAuto}
+	saveParallaxWalls(reg)
+
+	parallaxCutPID.Store(0)
+	parallaxLastFinish.Store(time.Now().Unix() - 5)
+	d := &daemon{}
+	d.ryoWallMu.Lock()
+	d.ryoWall = ryogamiFrame{Default: ryogamiFrameEntry{Path: wall}}
+	d.ryoWallMu.Unlock()
+	d.reconcileParallax(false)
+	if len(loadParallaxWalls().Layers[wall]) != 0 {
+		t.Fatal("reconcile started a new cut within the settle window")
+	}
+}
+
+func TestParallaxConfigFromDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	if got := parallaxConfigFromFile(); got.mode != parallaxModeAuto ||
+		got.model != "u2netp" || got.alphaMatting {
+		t.Fatalf("default config = %+v", got)
+	}
+	dir := filepath.Join(home, ".config", "ryoku")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "parallax.json"), []byte(
+		`{"mode":"manual","model":"birefnet-general-lite","alphaMatting":true}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := parallaxConfigFromFile()
+	if got.mode != parallaxModeManual || got.model != "birefnet-general-lite" || !got.alphaMatting {
+		t.Errorf("override config = %+v", got)
+	}
+}
+
+func TestListManualLayers(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	wall := filepath.Join(home, "wp.png")
+	writeFile(t, wall, "png")
+	dir := parallaxManualDir(wall)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"layer-03.png", "layer-01.png", "layer-02.png", "notes.txt", "layer-2.png"} {
+		writeFile(t, filepath.Join(dir, name), name)
+	}
+	layers := listManualLayers(wall)
+	if len(layers) != 3 {
+		t.Fatalf("layers = %d, want 3", len(layers))
+	}
+	want := []string{"Layer 1", "Layer 2", "Layer 3"}
+	wantSuffix := []string{"layer-01.png", "layer-02.png", "layer-03.png"}
+	for i, l := range layers {
+		if l.Label != want[i] {
+			t.Errorf("layer[%d].label = %q, want %q", i, l.Label, want[i])
+		}
+		if !strings.HasSuffix(l.Out, wantSuffix[i]) {
+			t.Errorf("layer[%d].out = %q, want suffix %q", i, l.Out, wantSuffix[i])
+		}
+	}
+}
+
+func TestListManualLayersMissingFolder(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	wall := filepath.Join(home, "wp.png")
+	writeFile(t, wall, "png")
+	layers := listManualLayers(wall)
+	if layers == nil || len(layers) != 0 {
+		t.Fatalf("layers = %#v, want a non-nil empty slice", layers)
+	}
+}
+
+func TestParallaxAddManualLayer(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(dir, ".local", "state"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+
+	wall := filepath.Join(dir, "Pictures", "wp.png")
+	if err := os.MkdirAll(filepath.Dir(wall), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, wall, "png")
+	existing := filepath.Join(parallaxManualDir(wall), "layer-01.png")
+	if err := os.MkdirAll(filepath.Dir(existing), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, existing, "a")
+
+	src := filepath.Join(dir, "candidate.png")
+	writeFile(t, src, "PNG")
+
+	d := &daemon{}
+	d.ryoWallMu.Lock()
+	d.ryoWall = ryogamiFrame{Default: ryogamiFrameEntry{Path: wall}}
+	d.ryoWallMu.Unlock()
+
+	got, err := d.parallaxAddManualLayer(src)
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	want := filepath.Join(parallaxManualDir(wall), "layer-02.png")
+	if got != want {
+		t.Fatalf("add returned %q, want %q", got, want)
+	}
+}
+
+func TestParallaxRemoveManualLayerRejectsPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(dir, ".local", "state"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+
+	wall := filepath.Join(dir, "wp.png")
+	writeFile(t, wall, "png")
+	outside := filepath.Join(dir, "evil.png")
+	writeFile(t, outside, "bad")
+
+	d := &daemon{}
+	d.ryoWallMu.Lock()
+	d.ryoWall = ryogamiFrame{Default: ryogamiFrameEntry{Path: wall}}
+	d.ryoWallMu.Unlock()
+
+	if err := d.parallaxRemoveManualLayer(outside); err == nil {
+		t.Fatal("removing outside the folder must fail")
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("outside file must survive: %v", err)
+	}
+}
+
+func TestParallaxManualFolderLayout(t *testing.T) {
+	cases := map[string]bool{
+		"layer-01.png":       true,
+		"layer-100.png":      true,
+		"layer-1.png":        false,
+		"Layer-01.png":       false,
+		"layer-01.jpg":       false,
+		"layer-01.png.bak":   false,
+		"layer-01-thumb.png": false,
+	}
+	for name, want := range cases {
+		if got := manualLayerRe.MatchString(name); got != want {
+			t.Errorf("%s -> %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestParallaxEngineBin(t *testing.T) {
+	t.Setenv("RYOKU_SHELL_DIR", "/dev/null")
+	if got := parallaxEngineBin(); got != "ryoku-parallax-engine" {
+		t.Fatalf("engine bin with bad RYOKU_SHELL_DIR = %q", got)
+	}
+}
+
+func TestParallaxSubjectOut(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	want := filepath.Join(home, "Pictures", "Parallax", "sunset", "layer-01.png")
+	if got := parallaxSubjectOut("/walls/sunset.jpg"); got != want {
+		t.Fatalf("subject out = %q, want %q", got, want)
+	}
+}
+
+func TestParallaxInpaintedOut(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	want := filepath.Join(home, "Pictures", "Parallax", "sunset", "background.png")
+	if got := parallaxInpaintedOut("/walls/sunset.jpg"); got != want {
+		t.Fatalf("inpainted out = %q, want %q", got, want)
+	}
+}

--- a/ryoku/shell/ipc/ryogami.go
+++ b/ryoku/shell/ipc/ryogami.go
@@ -177,6 +177,7 @@ func (d *daemon) consumeRyogamiFrames(r io.Reader) {
 		}
 		if srcChanged {
 			d.scheduleTheme()
+			d.scheduleParallax()
 		}
 	}
 }

--- a/ryoku/shell/quickshell/shell/modules/bar/framebars/menus/quicksettings/QuickSettingsParallax.qml
+++ b/ryoku/shell/quickshell/shell/modules/bar/framebars/menus/quicksettings/QuickSettingsParallax.qml
@@ -1,0 +1,1549 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell.Io
+import shell.services
+import "../../../../../components"
+import "../../../../parallax/Singletons" as PxCfg
+import "../../../../visualizer/Singletons" as VizCfg
+import "../../../../desktop/Singletons" as DesktopCfg
+
+// Parallax tab of the Super+Esc quick-settings panel. Plain English on
+// purpose (no I18n). Auto cuts the subject and recolours the background;
+// manual lists the wallpaper's layer-NN.png folder. Per-layer options
+// mirror the depth effect plus the layer model; sliders are drag-only.
+Item {
+    id: root
+
+    property real s: 1
+    property bool open: false
+    property var navigate: null
+    property var closePanel: null
+
+    readonly property bool checked: PxCfg.ParallaxBackend.checked
+    readonly property bool ready: PxCfg.ParallaxBackend.available
+    readonly property bool installing: PxCfg.ParallaxBackend.installing
+    readonly property int layerCount: PxCfg.Config.layers.length
+    readonly property bool hasLayers: root.wallActive && root.layerCount > 0
+    readonly property string activePath: PxCfg.Config.activePath
+    readonly property string wallMode: PxCfg.Config.wallMode
+    readonly property bool manualMode: root.wallMode === "manual"
+    readonly property bool autoMode: root.wallMode === "auto"
+    readonly property bool wallActive: PxCfg.Config.wallActive
+
+    property bool statusBusy: false
+    property bool busyStuck: false
+    property string stage: ""
+    property int statusPercent: 0
+
+    readonly property bool generating: (root.statusBusy && !root.busyStuck) || minBusy.running
+
+    property string draftCutTier: PxCfg.Config.cutTier()
+    readonly property bool detailDirty: root.draftCutTier !== PxCfg.Config.cutTier()
+    Connections {
+        target: PxCfg.Config
+        function onModelChanged() { if (!root.generating) root.draftCutTier = PxCfg.Config.cutTier(); }
+        function onAlphaMattingChanged() { if (!root.generating) root.draftCutTier = PxCfg.Config.cutTier(); }
+    }
+    onOpenChanged: {
+        if (root.open) {
+            root.draftCutTier = PxCfg.Config.cutTier();
+            root.rebuildScene();
+        }
+    }
+
+    property string expanded: "order"
+    property string activePreset: "none"
+
+    Timer {
+        id: rescanTimer
+        interval: 2500
+        onTriggered: {
+            if (root.manualMode) PxCfg.Config.refresh();
+        }
+    }
+
+    Timer { id: minBusy; interval: 900 }
+    Timer {
+        id: stuckGuard
+        interval: 50000
+        running: root.statusBusy && !root.busyStuck
+        onTriggered: root.busyStuck = true
+    }
+
+    function recut() {
+        if (root.activePath === "" || !root.ready) return;
+        minBusy.restart();
+        root.busyStuck = false;
+        root.statusBusy = true;
+        PxCfg.Config.setWallEnabled(true);
+        if (root.draftCutTier !== PxCfg.Config.cutTier())
+            PxCfg.Config.setCutTier(root.draftCutTier);
+        PxCfg.Config.refresh();
+        poll.restart();
+    }
+    function cancel() { PxCfg.Config.cancel(); }
+    function placeVisualizer() {
+        const st = ShellState.forActive();
+        if (st) st.visualizerPlacing = true;
+        if (root.closePanel) root.closePanel();
+    }
+    function resetScene() {
+        PxCfg.Config.setScene([]);
+        root.rebuildScene();
+    }
+
+    Timer {
+        id: poll
+        interval: 500
+        repeat: true
+        running: root.open
+        triggeredOnStart: true
+        onTriggered: statusProc.running = true
+    }
+    Process {
+        id: statusProc
+        command: ["ryoku-shell", "parallax", "status"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                let d = {};
+                try { d = JSON.parse(("" + this.text).trim() || "{}"); } catch (e) {}
+                const wasBusy = root.statusBusy;
+                root.statusBusy = d.busy === true;
+                root.stage = (typeof d.stage === "string") ? d.stage : "";
+                root.statusPercent = (typeof d.percent === "number") ? d.percent : 0;
+                if (!root.statusBusy) {
+                    root.busyStuck = false;
+                    if (wasBusy) minBusy.stop();
+                }
+            }
+        }
+    }
+
+    property var sceneRows: []
+    function rebuildScene() {
+        const names = {
+            "clock": "Clock", "calendar": "Calendar", "music": "Music",
+            "aio": "AIO", "stats": "Stats", "weather": "Weather",
+            "notes": "Notes"
+        };
+        const rows = [];
+        try {
+            // Front-first display: highest scene index is the first row.
+            const scene = PxCfg.Config.effectiveScene();
+            for (let k = scene.length - 1; k >= 0; k--) {
+                const id = scene[k];
+                if (id === "wallpaper") continue;
+                if (id === "visualizer") {
+                    if (VizCfg.Config.enabled)
+                        rows.push({ id: id, label: "Visualizer", icon: "graphic_eq", movable: true });
+                    continue;
+                }
+                if (id.indexOf("layer:") === 0) {
+                    const i = parseInt(id.slice(6));
+                    const lbl = PxCfg.Config.layerLabel(i).toLowerCase();
+                    rows.push({
+                        id: id,
+                        label: PxCfg.Config.layerLabel(i),
+                        icon: lbl.indexOf("subject") === 0 ? "person"
+                            : lbl.indexOf("object") === 0 ? "category"
+                            : "layers",
+                        movable: true
+                    });
+                    continue;
+                }
+                if (id.indexOf("widget:") !== 0) continue;
+                const w = id.slice(7);
+                if (!root.widgetOn(w)) continue;
+                rows.push({ id: id, label: names[w] || w, icon: "widgets", movable: true });
+            }
+        } catch (e) {
+            rows.length = 0;
+        }
+        if (rows.length === 0) {
+            for (const w of ["clock", "calendar", "music", "aio", "stats", "weather", "notes"]) {
+                if (!root.widgetOn(w)) continue;
+                rows.push({ id: "widget:" + w, label: names[w] || w, icon: "widgets", movable: true });
+            }
+            if (VizCfg.Config.enabled)
+                rows.push({ id: "visualizer", label: "Visualizer", icon: "graphic_eq", movable: true });
+            for (let i = PxCfg.Config.layers.length; i >= 1; i--) {
+                rows.push({ id: "layer:" + i, label: PxCfg.Config.layerLabel(i), icon: "layers", movable: true });
+            }
+        }
+        root.sceneRows = rows;
+    }
+    function widgetOn(id) {
+        switch (id) {
+        case "clock": return DesktopCfg.Config.clockEnabled;
+        case "calendar": return DesktopCfg.Config.calendarEnabled;
+        case "music": return DesktopCfg.Config.musicEnabled;
+        case "aio": return DesktopCfg.Config.aioEnabled;
+        case "stats": return DesktopCfg.Config.statsEnabled;
+        case "weather": return DesktopCfg.Config.weatherEnabled;
+        case "notes": return DesktopCfg.Config.notesEnabled;
+        }
+        return true;
+    }
+    function moveOrder(id, dir) {
+        const scene = PxCfg.Config.effectiveScene().slice();
+        const i = scene.indexOf(id);
+        const j = i + dir;
+        if (i < 0 || j < 0 || j >= scene.length) return;
+        const tmp = scene[i]; scene[i] = scene[j]; scene[j] = tmp;
+        PxCfg.Config.setScene(scene);
+        root.rebuildScene();
+    }
+    function removeLayer(layerIdx) {
+        if (layerIdx < 1 || layerIdx > PxCfg.Config.layers.length) return;
+        PxCfg.Config.removeManualLayer(PxCfg.Config.layerPath(layerIdx));
+    }
+    Connections {
+        target: PxCfg.Config
+        function onWallSceneChanged() { root.rebuildScene(); }
+        function onActivePathChanged() { root.rebuildScene(); }
+        function onWallBandsChanged() { root.rebuildScene(); }
+        function onLayersChanged() { root.rebuildScene(); }
+        function onWallModeChanged() { root.rebuildScene(); }
+    }
+    Connections {
+        target: DesktopCfg.Config
+        function onClockEnabledChanged() { root.rebuildScene(); }
+        function onCalendarEnabledChanged() { root.rebuildScene(); }
+        function onMusicEnabledChanged() { root.rebuildScene(); }
+        function onAioEnabledChanged() { root.rebuildScene(); }
+        function onStatsEnabledChanged() { root.rebuildScene(); }
+        function onWeatherEnabledChanged() { root.rebuildScene(); }
+        function onNotesEnabledChanged() { root.rebuildScene(); }
+    }
+    Component.onCompleted: root.rebuildScene()
+
+    component Sec: Text {
+        id: sec
+        property string title: ""
+        text: sec.title.toUpperCase()
+        color: Theme.primary
+        font.family: Theme.fontPrimary
+        font.pixelSize: Theme.fontSm - 3
+        font.weight: Font.DemiBold
+        width: parent ? parent.width : 0
+    }
+
+    component PxTile: Rectangle {
+        id: tile
+        property string icon: "circle"
+        property string label: ""
+        property string sub: ""
+        property bool on: false
+        property bool available: true
+        signal toggled()
+        width: parent ? parent.width : 0
+        height: 58
+        radius: Theme.radiusWidget
+        color: "transparent"
+        opacity: tile.available ? 1 : 0.4
+        Row {
+            anchors.fill: parent
+            anchors.margins: 8
+            spacing: 10
+            Rectangle {
+                width: 34
+                height: 34
+                radius: 17
+                anchors.verticalCenter: parent.verticalCenter
+                color: tile.on ? Theme.primary
+                    : Qt.rgba(Theme.onSurface.r, Theme.onSurface.g, Theme.onSurface.b, 0.08)
+                MaterialIcon {
+                    anchors.centerIn: parent
+                    text: tile.icon
+                    font.pixelSize: 16
+                    color: tile.on ? Theme.inkOn(Theme.primary, Theme.onPrimary) : Theme.onSurface
+                }
+            }
+            Column {
+                width: parent.width - 34 - 10 - 46
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: 1
+                Text {
+                    width: parent.width
+                    text: tile.label
+                    color: Theme.onSurface
+                    font.family: Theme.fontPrimary
+                    font.pixelSize: Theme.fontSm
+                    font.weight: Font.DemiBold
+                    elide: Text.ElideRight
+                }
+                Text {
+                    width: parent.width
+                    visible: tile.sub.length > 0
+                    text: tile.sub
+                    color: Theme.onSurfaceVariant
+                    font.family: Theme.fontPrimary
+                    font.pixelSize: Theme.fontSm - 3
+                    elide: Text.ElideRight
+                }
+            }
+            Rectangle {
+                width: 40
+                height: 22
+                radius: 11
+                anchors.verticalCenter: parent.verticalCenter
+                color: tile.on ? Theme.primary : Qt.rgba(Theme.onSurface.r, Theme.onSurface.g, Theme.onSurface.b, 0.14)
+                Rectangle {
+                    width: 18
+                    height: 18
+                    radius: 9
+                    x: tile.on ? 19 : 2
+                    anchors.verticalCenter: parent.verticalCenter
+                    color: Theme.surface
+                    Behavior on x { NumberAnimation { duration: Motion.fast } }
+                }
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: tile.toggled()
+                }
+            }
+        }
+    }
+
+    component PxNavRow: Rectangle {
+        id: nav
+        property string icon: "circle"
+        property string label: ""
+        property string sub: ""
+        signal activated()
+        width: parent ? parent.width : 0
+        height: 54
+        radius: Theme.radiusWidget
+        color: navMa.containsMouse ? Qt.rgba(Theme.onSurface.r, Theme.onSurface.g, Theme.onSurface.b, 0.06) : "transparent"
+        Behavior on color { ColorAnimation { duration: Motion.crossfade } }
+        Row {
+            anchors.fill: parent
+            anchors.margins: 8
+            spacing: 10
+            MaterialIcon {
+                anchors.verticalCenter: parent.verticalCenter
+                text: nav.icon
+                font.pixelSize: 18
+                color: Theme.onSurfaceVariant
+            }
+            Column {
+                width: parent.width - 28
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: 1
+                Text {
+                    width: parent.width
+                    text: nav.label
+                    color: Theme.onSurface
+                    font.family: Theme.fontPrimary
+                    font.pixelSize: Theme.fontSm
+                    font.weight: Font.DemiBold
+                    elide: Text.ElideRight
+                }
+                Text {
+                    width: parent.width
+                    visible: nav.sub.length > 0
+                    text: nav.sub
+                    color: Theme.onSurfaceVariant
+                    font.family: Theme.fontPrimary
+                    font.pixelSize: Theme.fontSm - 3
+                    wrapMode: Text.WordWrap
+                }
+            }
+        }
+        MouseArea {
+            id: navMa
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: nav.activated()
+        }
+    }
+
+    component PxSeg: Rectangle {
+        id: seg
+        property var options: []   // [{ id, label }]
+        property string current: ""
+        signal chose(string id)
+        implicitHeight: 38
+        radius: Theme.radiusWidget
+        color: Qt.rgba(Theme.onSurface.r, Theme.onSurface.g, Theme.onSurface.b, 0.06)
+        border.width: 1
+        border.color: Qt.rgba(Theme.outline.r, Theme.outline.g, Theme.outline.b, 0.30)
+        width: parent ? parent.width : 0
+        Row {
+            anchors.fill: parent
+            anchors.margins: 4
+            spacing: 4
+            Repeater {
+                model: seg.options
+                delegate: Rectangle {
+                    id: opt
+                    required property var modelData
+                    readonly property bool active: opt.modelData.id === seg.current
+                    width: (parent.width - (seg.options.length - 1) * 4) / Math.max(1, seg.options.length)
+                    height: parent.height
+                    radius: Theme.radiusWidget - 4
+                    color: opt.active ? Theme.primary
+                        : optMa.containsMouse ? Qt.rgba(Theme.onSurface.r, Theme.onSurface.g, Theme.onSurface.b, 0.10)
+                        : "transparent"
+                    Behavior on color { ColorAnimation { duration: Motion.crossfade } }
+                    Text {
+                        anchors.centerIn: parent
+                        text: opt.modelData.label
+                        color: opt.active ? Theme.inkOn(Theme.primary, Theme.onPrimary) : Theme.onSurface
+                        font.family: Theme.fontPrimary
+                        font.pixelSize: Theme.fontSm - 1
+                        font.weight: opt.active ? Font.DemiBold : Font.Normal
+                    }
+                    MouseArea {
+                        id: optMa
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: seg.chose(opt.modelData.id)
+                    }
+                }
+            }
+        }
+    }
+
+    component Field: Column {
+        id: field
+        property string title: ""
+        property string hint: ""
+        property var choices: []
+        property string current: ""
+        signal chose(string id)
+        width: parent ? parent.width : 0
+        spacing: 5
+        Text {
+            text: field.title
+            color: Theme.onSurface
+            font.family: Theme.fontPrimary
+            font.pixelSize: Theme.fontSm
+            font.weight: Font.DemiBold
+        }
+        Text {
+            width: field.width
+            visible: field.hint.length > 0
+            text: field.hint
+            wrapMode: Text.WordWrap
+            color: Qt.rgba(Theme.onSurfaceVariant.r, Theme.onSurfaceVariant.g, Theme.onSurfaceVariant.b, 0.9)
+            font.family: Theme.fontPrimary
+            font.pixelSize: Theme.fontSm - 3
+        }
+        PxSeg {
+            width: field.width
+            options: field.choices
+            current: field.current
+            onChose: id => field.chose(id)
+        }
+    }
+
+    // Drag-only: no wheel handler, so scrolling never changes a value.
+    component DragSlider: Item {
+        id: ds
+        property string title: ""
+        property real value: 0
+        property real min: 0
+        property real max: 1
+        property int decimals: 2
+        property string unit: ""
+        signal changed(real v)
+        width: parent ? parent.width : 0
+        height: 46
+        function valueAt(mx) {
+            const t = track.width - 14;
+            const frac = Math.max(0, Math.min(1, (mx - 7) / Math.max(1, t)));
+            return ds.min + frac * (ds.max - ds.min);
+        }
+        Text {
+            id: dsLabel
+            anchors.left: parent.left
+            anchors.top: parent.top
+            text: ds.title
+            color: Theme.onSurface
+            font.family: Theme.fontPrimary
+            font.pixelSize: Theme.fontSm - 1
+            font.weight: Font.DemiBold
+        }
+        Text {
+            anchors.right: parent.right
+            anchors.top: parent.top
+            text: ds.value.toFixed(ds.decimals) + ds.unit
+            color: Theme.onSurfaceVariant
+            font.family: Theme.fontPrimary
+            font.pixelSize: Theme.fontSm - 2
+        }
+        Rectangle {
+            id: track
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            height: 6
+            radius: 3
+            color: Qt.rgba(Theme.onSurface.r, Theme.onSurface.g, Theme.onSurface.b, 0.14)
+            Rectangle {
+                id: fill
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+                height: parent.height
+                radius: 3
+                color: Theme.primary
+                width: 7 + (track.width - 14) * ((ds.value - ds.min) / Math.max(0.0001, ds.max - ds.min))
+            }
+            Rectangle {
+                id: thumb
+                width: 14
+                height: 14
+                radius: 7
+                anchors.verticalCenter: parent.verticalCenter
+                x: Math.max(0, Math.min(track.width - 14, 7 + (track.width - 14) * ((ds.value - ds.min) / Math.max(0.0001, ds.max - ds.min)) - 7))
+                color: Theme.surface
+                border.width: 2
+                border.color: Theme.primary
+            }
+            MouseArea {
+                anchors.fill: parent
+                anchors.margins: -12
+                hoverEnabled: true
+                cursorShape: Qt.SizeHorCursor
+                onPositionChanged: mouse => {
+                    if (mouse.buttons & Qt.LeftButton)
+                        ds.changed(ds.valueAt(mouse.x));
+                }
+                onPressed: mouse => ds.changed(ds.valueAt(mouse.x))
+            }
+        }
+    }
+
+    // Shadow direction dial (0 = right, 90 = down).
+    component AngleDial: Item {
+        id: dial
+        property real angle: 90
+        signal changed(real deg)
+        width: 88
+        height: 88
+        readonly property real rad: dial.angle * Math.PI / 180
+        readonly property real cx: 44
+        readonly property real cy: 44
+        readonly property real dotR: 26
+
+        Rectangle {
+            anchors.centerIn: parent
+            width: 80
+            height: 80
+            radius: 40
+            gradient: Gradient {
+                GradientStop { position: 0.0; color: Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.08) }
+                GradientStop { position: 1.0; color: Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.16) }
+            }
+            border.width: 1
+            border.color: Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.35)
+        }
+        Repeater {
+            model: [0, 90, 180, 270]
+            delegate: Rectangle {
+                required property int modelData
+                readonly property real t: modelData * Math.PI / 180
+                width: 2
+                height: 5
+                radius: 1
+                color: Qt.rgba(Theme.onSurface.r, Theme.onSurface.g, Theme.onSurface.b, 0.5)
+                x: dial.cx - 1 + Math.cos(t) * 36
+                y: dial.cy - 2.5 + Math.sin(t) * 36
+            }
+        }
+        Rectangle {
+            id: needle
+            width: 2
+            height: dial.dotR - 4
+            radius: 1
+            color: Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.9)
+            x: dial.cx - 1
+            y: dial.cy - (dial.dotR - 4)
+            transformOrigin: Item.Bottom
+            rotation: dial.angle + 90
+            Behavior on rotation { NumberAnimation { duration: Motion.fast; easing.type: Easing.OutCubic } }
+        }
+        Rectangle {
+            anchors.centerIn: parent
+            width: 8
+            height: 8
+            radius: 4
+            color: Theme.onSurface
+        }
+        Rectangle {
+            id: dot
+            width: 20
+            height: 20
+            radius: 10
+            color: Theme.primary
+            border.width: 3
+            border.color: Theme.surface
+            x: dial.cx - 10 + Math.cos(dial.rad) * dial.dotR
+            y: dial.cy - 10 + Math.sin(dial.rad) * dial.dotR
+            Behavior on x { NumberAnimation { duration: Motion.fast; easing.type: Easing.OutCubic } }
+            Behavior on y { NumberAnimation { duration: Motion.fast; easing.type: Easing.OutCubic } }
+        }
+        MouseArea {
+            anchors.fill: parent
+            anchors.margins: -8
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            function update(mx, my) {
+                const dx = mx - dial.cx;
+                const dy = my - dial.cy;
+                if (Math.abs(dx) < 2 && Math.abs(dy) < 2) return;
+                let deg = Math.atan2(dy, dx) * 180 / Math.PI;
+                if (deg < 0) deg += 360;
+                dial.changed(Math.round(deg));
+            }
+            onPositionChanged: mouse => {
+                if (mouse.buttons & Qt.LeftButton)
+                    update(mouse.x, mouse.y);
+            }
+            onPressed: mouse => update(mouse.x, mouse.y)
+        }
+    }
+
+    component PxBtn: Rectangle {
+        id: btn
+        property string icon: ""
+        property string label: ""
+        property string kind: "outlined"
+        property bool enabledAct: true
+        signal act()
+        width: parent ? parent.width : 0
+        height: 44
+        radius: Theme.radiusWidget
+        opacity: btn.enabledAct ? 1 : 0.4
+        color: btn.kind === "filled"
+            ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, ma.containsMouse && btn.enabledAct ? 0.30 : 0.22)
+            : (ma.containsMouse && btn.enabledAct) ? Qt.rgba(Theme.onSurface.r, Theme.onSurface.g, Theme.onSurface.b, 0.08) : "transparent"
+        border.width: btn.kind === "ghost" ? 0 : 1
+        border.color: btn.kind === "filled"
+            ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.55)
+            : Qt.rgba(Theme.outline.r, Theme.outline.g, Theme.outline.b, 0.35)
+        Behavior on color { ColorAnimation { duration: Motion.crossfade } }
+        Row {
+            anchors.centerIn: parent
+            spacing: 8
+            MaterialIcon {
+                anchors.verticalCenter: parent.verticalCenter
+                text: btn.icon
+                font.pixelSize: 18
+                fill: btn.kind === "filled" ? 1 : 0
+                color: Theme.onSurface
+            }
+            Text {
+                anchors.verticalCenter: parent.verticalCenter
+                text: btn.label
+                color: Theme.onSurface
+                font.family: Theme.fontPrimary
+                font.pixelSize: Theme.fontSm
+                font.weight: Font.DemiBold
+            }
+        }
+        MouseArea {
+            id: ma
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: btn.enabledAct ? Qt.PointingHandCursor : Qt.ArrowCursor
+            onClicked: if (btn.enabledAct) btn.act()
+        }
+    }
+
+    component StopBtn: Rectangle {
+        id: sbtn
+        signal clicked()
+        width: 64
+        height: 28
+        radius: 14
+        color: ma.containsMouse ? Qt.rgba(Theme.onSurface.r, Theme.onSurface.g, Theme.onSurface.b, 0.16) : "transparent"
+        border.width: 1
+        border.color: Qt.rgba(Theme.outline.r, Theme.outline.g, Theme.outline.b, 0.30)
+        Text {
+            anchors.centerIn: parent
+            text: "Stop"
+            color: Theme.onSurface
+            font.family: Theme.fontPrimary
+            font.pixelSize: Theme.fontSm - 1
+            font.weight: Font.DemiBold
+        }
+        MouseArea {
+            id: ma
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: sbtn.clicked()
+        }
+    }
+
+    component SceneRow: Item {
+        id: row
+        property var rowData: null
+        property int rowIndex: 0
+        property int rowCount: 0
+        signal move(string id, int dir)
+        width: parent ? parent.width : 0
+        height: 38
+        readonly property string rowLabel: row.rowData ? (row.rowData.label ? row.rowData.label : "") : ""
+        readonly property string rowIcon: row.rowData ? (row.rowData.icon ? row.rowData.icon : "") : ""
+        readonly property bool canMove: row.rowData ? row.rowData.movable === true : false
+        Row {
+            id: rowLine
+            anchors.fill: parent
+            spacing: 10
+            MaterialIcon {
+                anchors.verticalCenter: parent.verticalCenter
+                text: row.rowIcon
+                font.pixelSize: 16
+                color: Theme.onSurfaceVariant
+                width: 18
+            }
+            Text {
+                anchors.verticalCenter: parent.verticalCenter
+                elide: Text.ElideRight
+                text: row.rowLabel
+                color: Theme.onSurface
+                font.family: Theme.fontPrimary
+                font.pixelSize: Theme.fontSm - 1
+            }
+            Item { width: row.rowCount > 0 ? 74 : 0; height: 26 }
+            Item {
+                width: 30; height: 26
+                visible: row.canMove
+                opacity: row.rowIndex > 0 ? 1 : 0.3
+                enabled: row.rowIndex > 0
+                MaterialIcon {
+                    anchors.centerIn: parent
+                    text: "keyboard_arrow_up"
+                    font.pixelSize: 18
+                    color: upMa.containsMouse ? Theme.onSurface : Theme.onSurfaceVariant
+                }
+                MouseArea {
+                    id: upMa
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: parent.enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                    onClicked: row.move(row.rowData ? row.rowData.id : "", 1)
+                }
+            }
+            Item {
+                width: 30; height: 26
+                visible: row.canMove
+                opacity: row.rowIndex < row.rowCount - 1 ? 1 : 0.3
+                enabled: row.rowIndex < row.rowCount - 1
+                MaterialIcon {
+                    anchors.centerIn: parent
+                    text: "keyboard_arrow_down"
+                    font.pixelSize: 18
+                    color: downMa.containsMouse ? Theme.onSurface : Theme.onSurfaceVariant
+                }
+                MouseArea {
+                    id: downMa
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: parent.enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                    onClicked: row.move(row.rowData ? row.rowData.id : "", -1)
+                }
+            }
+        }
+    }
+
+    component PanelHeader: Item {
+        id: ph
+        property string icon: "layers"
+        property string label: ""
+        property bool expanded: false
+        property bool showEye: false
+        property bool eyeOn: true
+        signal toggle()
+        signal eye()
+        width: parent ? parent.width : 0
+        height: 44
+        Row {
+            anchors.fill: parent
+            spacing: 10
+            MaterialIcon {
+                anchors.verticalCenter: parent.verticalCenter
+                text: ph.expanded ? "keyboard_arrow_down" : "keyboard_arrow_right"
+                font.pixelSize: 18
+                color: Theme.onSurfaceVariant
+            }
+            MaterialIcon {
+                anchors.verticalCenter: parent.verticalCenter
+                text: ph.icon
+                font.pixelSize: 16
+                color: Theme.onSurfaceVariant
+                width: 18
+            }
+            Text {
+                anchors.verticalCenter: parent.verticalCenter
+                text: ph.label
+                color: Theme.onSurface
+                font.family: Theme.fontPrimary
+                font.pixelSize: Theme.fontSm
+                font.weight: Font.DemiBold
+                elide: Text.ElideRight
+            }
+            Item {
+                anchors.verticalCenter: parent.verticalCenter
+                width: 24
+                height: 24
+                visible: ph.showEye
+                MaterialIcon {
+                    anchors.centerIn: parent
+                    text: ph.eyeOn ? "visibility" : "visibility_off"
+                    font.pixelSize: 16
+                    color: ph.eyeOn ? Theme.primary : Theme.onSurfaceVariant
+                }
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: ph.eye()
+                }
+            }
+        }
+        MouseArea {
+            anchors.fill: parent
+            onClicked: ph.toggle()
+        }
+    }
+
+    Rectangle { anchors.fill: parent; color: Theme.surface }
+
+    Flickable {
+        anchors.fill: parent
+        anchors.margins: 12
+        contentWidth: width
+        contentHeight: col.implicitHeight
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+        interactive: contentHeight > height
+
+        Column {
+            id: col
+            width: parent.width
+            spacing: 12
+
+            Column {
+                width: parent.width
+                spacing: 2
+                Text {
+                    text: "Parallax"
+                    color: Theme.onSurface
+                    font.family: Theme.fontPrimary
+                    font.pixelSize: Theme.fontLg
+                    font.weight: Font.DemiBold
+                }
+                Text {
+                    width: parent.width
+                    wrapMode: Text.WordWrap
+                    text: "Cut the subject from your wallpaper (auto) or drop numbered PNGs per wallpaper (manual), then tune each layer and the on-screen order."
+                    color: Theme.onSurfaceVariant
+                    font.family: Theme.fontPrimary
+                    font.pixelSize: Theme.fontSm - 1
+                }
+            }
+
+            Text {
+                width: parent.width
+                visible: !root.checked
+                text: "Preparing engine..."
+                color: Theme.onSurfaceVariant
+                font.family: Theme.fontPrimary
+                font.pixelSize: Theme.fontSm - 1
+            }
+
+            PxNavRow {
+                width: parent.width
+                visible: root.checked && !root.ready
+                icon: "download"
+                label: PxCfg.ParallaxBackend.installing ? "Installing engine..." : "Install engine"
+                sub: PxCfg.ParallaxBackend.installing
+                    ? PxCfg.ParallaxBackend.progress
+                    : "A one-time download to detect subjects."
+                onActivated: if (!PxCfg.ParallaxBackend.installing)
+                    PxCfg.ParallaxBackend.install()
+            }
+
+            PxTile {
+                width: parent.width
+                visible: root.checked
+                icon: "view_in_ar"
+                label: "Parallax layers"
+                sub: root.generating
+                    ? (root.stage.length > 0 ? root.stage : "Cutting...")
+                    : (root.wallActive ? "On" : "Off")
+                on: root.wallActive
+                onToggled: {
+                    if (!root.wallActive) {
+                        PxCfg.Config.setEnabledGlobal(true);
+                        PxCfg.Config.setWallEnabled(true);
+                    } else {
+                        PxCfg.Config.setWallEnabled(false);
+                    }
+                }
+            }
+
+            Rectangle {
+                id: preview
+                width: parent.width
+                height: 200
+                radius: Theme.radiusWidget
+                clip: true
+                color: Qt.rgba(Theme.onSurface.r, Theme.onSurface.g, Theme.onSurface.b, 0.04)
+                border.width: 1
+                border.color: Qt.rgba(Theme.outline.r, Theme.outline.g, Theme.outline.b, 0.22)
+
+                property real demoT: 0
+                Timer {
+                    interval: 50
+                    repeat: true
+                    running: preview.visible && !root.generating
+                    onTriggered: preview.demoT += 50
+                }
+                readonly property real demoNX: Math.sin(preview.demoT / 900)
+                readonly property real demoNY: Math.cos(preview.demoT / 1100)
+
+                Repeater {
+                    model: root.layerCount
+                    delegate: Item {
+                        id: pvLayer
+                        required property int index
+                        readonly property int li: index + 1
+                        anchors.fill: parent
+                        z: PxCfg.Config.sceneZ("layer:" + pvLayer.li)
+                        visible: PxCfg.Config.layerEnabled2(index)
+                        Image {
+                            anchors.fill: parent
+                            source: PxCfg.Config.layerUrl(pvLayer.li)
+                            cache: false
+                            asynchronous: true
+                            fillMode: Image.PreserveAspectFit
+                            opacity: status === Image.Ready ? PxCfg.Config.opacityFor(pvLayer.index) : 0
+                            transform: Translate {
+                                x: preview.demoNX * 9
+                                    * PxCfg.Config.parallaxFor(pvLayer.index)
+                                    * (0.4 + PxCfg.Config.depthFor(pvLayer.index) * 1.2)
+                                    * PxCfg.Config.mouseSensitivity
+                                    + PxCfg.Config.offsetXFor(pvLayer.index) / 10
+                                y: preview.demoNY * 9
+                                    * PxCfg.Config.parallaxFor(pvLayer.index)
+                                    * (0.4 + PxCfg.Config.depthFor(pvLayer.index) * 1.2)
+                                    * PxCfg.Config.mouseSensitivity
+                                    + PxCfg.Config.offsetYFor(pvLayer.index) / 10
+                            }
+                        }
+                    }
+                }
+
+                Text {
+                    anchors.centerIn: parent
+                    width: parent.width - 40
+                    horizontalAlignment: Text.AlignHCenter
+                    wrapMode: Text.WordWrap
+                    visible: root.checked && root.activePath !== "" && !root.hasLayers && !root.generating
+                    text: root.manualMode
+                        ? "Drop layer-NN.png files into the manual folder for this wallpaper."
+                        : "No layers for this wallpaper yet."
+                    color: Theme.onSurfaceVariant
+                    font.family: Theme.fontPrimary
+                    font.pixelSize: Theme.fontSm - 1
+                }
+
+                Column {
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.bottom: parent.bottom
+                    anchors.margins: 12
+                    spacing: 6
+                    visible: root.generating
+                    Text {
+                        width: parent.width
+                        text: root.stage.length > 0 ? root.stage : "Cutting layer"
+                        color: Theme.onSurface
+                        font.family: Theme.fontPrimary
+                        font.pixelSize: Theme.fontSm - 1
+                        font.weight: Font.DemiBold
+                        elide: Text.ElideRight
+                    }
+                    Row {
+                        width: parent.width
+                        spacing: 8
+                        Rectangle {
+                            width: parent.width - 72
+                            height: 4
+                            radius: 2
+                            color: Qt.rgba(Theme.onSurface.r, Theme.onSurface.g, Theme.onSurface.b, 0.14)
+                            Rectangle {
+                                anchors.left: parent.left
+                                anchors.top: parent.top
+                                anchors.bottom: parent.bottom
+                                radius: 2
+                                color: Theme.primary
+                                width: Math.max(0, Math.min(parent.width, parent.width * (root.statusPercent / 100)))
+                                Behavior on width { NumberAnimation { duration: Motion.crossfade } }
+                            }
+                        }
+                        Text {
+                            anchors.verticalCenter: parent.verticalCenter
+                            text: root.statusPercent + "%"
+                            color: Theme.onSurfaceVariant
+                            font.family: Theme.fontPrimary
+                            font.pixelSize: Theme.fontSm - 3
+                            width: 40
+                            horizontalAlignment: Text.AlignRight
+                        }
+                        StopBtn {
+                            anchors.verticalCenter: parent.verticalCenter
+                            onClicked: root.cancel()
+                        }
+                    }
+                }
+            }
+
+            Sec { title: "Mode" }
+            Field {
+                title: "Cutout source"
+                hint: "Auto cuts the subject with the engine and recolours the hole. Manual lists the layer files you place in the wallpaper's folder."
+                choices: [
+                    { id: "auto", label: "Auto (subject)" },
+                    { id: "manual", label: "Manual (numbered)" }
+                ]
+                current: root.wallMode
+                onChose: id => {
+                    PxCfg.Config.setMode(id);
+                    root.rebuildScene();
+                }
+            }
+
+            Column {
+                width: parent.width
+                spacing: 10
+                visible: root.autoMode
+
+                Sec { title: "Quality" }
+                Field {
+                    title: "Cutout detail"
+                    hint: "Higher detail traces hair and fine edges."
+                    choices: PxCfg.ParallaxBackend.hasModel("birefnet-general-lite")
+                        ? [{ id: "draft", label: "Draft" }, { id: "standard", label: "Standard" }, { id: "fine", label: "Fine" }]
+                        : [{ id: "draft", label: "Draft" }, { id: "standard", label: "Standard" }]
+                    current: root.draftCutTier
+                    onChose: id => root.draftCutTier = id
+                }
+                PxBtn {
+                    visible: root.ready
+                    kind: "filled"
+                    icon: root.generating ? "hourglass_top" : "cached"
+                    label: root.generating
+                        ? (root.stage.length > 0 ? root.stage + "..." : "Cutting...")
+                        : "Cut the subject"
+                    enabledAct: root.ready && !root.generating
+                    onAct: root.recut()
+                }
+            }
+
+            Column {
+                width: parent.width
+                spacing: 10
+                visible: root.manualMode
+
+                Sec { title: "Layers" }
+                Text {
+                    width: parent.width
+                    wrapMode: Text.WordWrap
+                    text: "Drop PNGs named layer-NN.png into the folder for this wallpaper."
+                    color: Theme.onSurfaceVariant
+                    font.family: Theme.fontPrimary
+                    font.pixelSize: Theme.fontSm - 3
+                }
+                PxBtn {
+                    kind: "filled"
+                    icon: "folder_open"
+                    label: "Open layers folder"
+                    onAct: {
+                        PxCfg.ParallaxBackend.openManualFolderFor(root.activePath);
+                        rescanTimer.restart();
+                    }
+                }
+                PxBtn {
+                    kind: "outlined"
+                    icon: "cached"
+                    label: "Rescan layers"
+                    onAct: PxCfg.Config.refresh()
+                }
+                Text {
+                    width: parent.width
+                    text: root.layerCount === 0
+                        ? "No layers yet."
+                        : root.layerCount + " layers"
+                    color: Theme.onSurfaceVariant
+                    font.family: Theme.fontPrimary
+                    font.pixelSize: Theme.fontSm - 3
+                }
+                Repeater {
+                    model: root.layerCount
+                    delegate: Item {
+                        id: manualRow
+                        required property int index
+                        readonly property int li: index + 1
+                        width: parent ? parent.width : 0
+                        implicitHeight: 64
+                        Row {
+                            anchors.fill: parent
+                            anchors.rightMargin: 40
+                            spacing: 10
+                            Rectangle {
+                                width: 56
+                                height: 56
+                                radius: Theme.radiusWidget
+                                color: Qt.rgba(Theme.onSurface.r, Theme.onSurface.g, Theme.onSurface.b, 0.06)
+                                border.width: 1
+                                border.color: Qt.rgba(Theme.outline.r, Theme.outline.g, Theme.outline.b, 0.18)
+                                clip: true
+                                Image {
+                                    anchors.fill: parent
+                                    source: PxCfg.Config.layerUrl(manualRow.li)
+                                    cache: false
+                                    asynchronous: true
+                                    fillMode: Image.PreserveAspectFit
+                                    sourceSize.width: 56
+                                    sourceSize.height: 56
+                                    opacity: status === Image.Ready ? 1 : 0
+                                }
+                            }
+                            Column {
+                                anchors.verticalCenter: parent.verticalCenter
+                                width: parent.width - 56 - 10
+                                spacing: 2
+                                Text {
+                                    text: PxCfg.Config.layerLabel(manualRow.li)
+                                    color: Theme.onSurface
+                                    font.family: Theme.fontPrimary
+                                    font.pixelSize: Theme.fontSm
+                                    font.weight: Font.DemiBold
+                                }
+                                Text {
+                                    text: PxCfg.Config.layerPath(manualRow.li).split("/").pop()
+                                    color: Theme.onSurfaceVariant
+                                    font.family: Theme.fontPrimary
+                                    font.pixelSize: Theme.fontSm - 3
+                                    elide: Text.ElideMiddle
+                                    width: parent.width
+                                }
+                            }
+                        }
+                        Item {
+                            anchors.right: parent.right
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: 32
+                            height: 32
+                            MaterialIcon {
+                                anchors.centerIn: parent
+                                text: "delete"
+                                font.pixelSize: 16
+                                color: delMa.containsMouse ? Theme.onSurface : Theme.onSurfaceVariant
+                            }
+                            MouseArea {
+                                id: delMa
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: root.removeLayer(manualRow.li)
+                            }
+                        }
+                    }
+                }
+            }
+
+            Item {
+                width: parent.width
+                visible: root.checked
+                implicitHeight: accordion.implicitHeight
+                Column {
+                    id: accordion
+                    width: parent.width
+                    spacing: 6
+
+                    Sec { title: "Layers" }
+
+                    Text {
+                        width: parent.width
+                        visible: root.layerCount === 0
+                        wrapMode: Text.WordWrap
+                        text: root.manualMode
+                            ? "No layers yet. Drop layer-NN.png files into the wallpaper folder."
+                            : "No layers yet. Turn Parallax on and cut the subject."
+                        color: Theme.onSurfaceVariant
+                        font.family: Theme.fontPrimary
+                        font.pixelSize: Theme.fontSm - 3
+                    }
+
+                    Item {
+                        width: parent.width
+                        implicitHeight: orderPanel.implicitHeight
+                        Column {
+                            id: orderPanel
+                            width: parent.width
+                            spacing: 4
+                            PanelHeader {
+                                icon: "sort"
+                                label: "Order"
+                                expanded: root.expanded === "order"
+                                onToggle: root.expanded = root.expanded === "order" ? "" : "order"
+                            }
+                            Column {
+                                width: parent.width
+                                spacing: 4
+                                visible: root.expanded === "order"
+                                Text {
+                                    width: parent.width
+                                    wrapMode: Text.WordWrap
+                                    text: "The on-screen stack, front first. Move any row: layers, widgets and the visualizer."
+                                    color: Theme.onSurfaceVariant
+                                    font.family: Theme.fontPrimary
+                                    font.pixelSize: Theme.fontSm - 3
+                                }
+                                Repeater {
+                                    model: root.sceneRows.length
+                                    delegate: SceneRow {
+                                        required property int index
+                                        rowData: root.sceneRows[index]
+                                        rowIndex: index
+                                        rowCount: root.sceneRows.length
+                                        onMove: (id, dir) => root.moveOrder(id, dir)
+                                    }
+                                }
+                                Row {
+                                    width: parent.width
+                                    spacing: 8
+                                    PxBtn {
+                                        width: (parent.width - 8) / 2
+                                        kind: "ghost"
+                                        icon: "restart_alt"
+                                        label: "Reset order"
+                                        onAct: root.resetScene()
+                                    }
+                                    PxBtn {
+                                        width: (parent.width - 8) / 2
+                                        kind: "ghost"
+                                        icon: "open_with"
+                                        label: "Place visualizer"
+                                        visible: VizCfg.Config.enabled && PxCfg.Config.sceneIndexOf("visualizer") >= 0
+                                        onAct: root.placeVisualizer()
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Repeater {
+                        model: root.layerCount
+                        delegate: Item {
+                            id: layerPanel
+                            required property int index
+                            readonly property int li: index + 1
+                            width: parent ? parent.width : 0
+                            implicitHeight: layerCol.implicitHeight
+                            Column {
+                                id: layerCol
+                                width: parent.width
+                                spacing: 4
+                                PanelHeader {
+                                    icon: {
+                                        const lbl = PxCfg.Config.layerLabel(layerPanel.li).toLowerCase();
+                                        return lbl.indexOf("subject") === 0 ? "person" : "layers";
+                                    }
+                                    label: PxCfg.Config.layerLabel(layerPanel.li)
+                                    expanded: root.expanded === "layer:" + layerPanel.li
+                                    showEye: true
+                                    eyeOn: PxCfg.Config.layerEnabled2(layerPanel.li - 1)
+                                    onToggle: root.expanded = root.expanded === "layer:" + layerPanel.li ? "" : "layer:" + layerPanel.li
+                                    onEye: PxCfg.Config.setLayerEnabled2(layerPanel.li - 1, !PxCfg.Config.layerEnabled2(layerPanel.li - 1))
+                                }
+
+                                Column {
+                                    width: parent.width
+                                    spacing: 8
+                                    visible: root.expanded === "layer:" + layerPanel.li
+
+                                    Rectangle {
+                                        width: parent.width
+                                        height: 120
+                                        radius: Theme.radiusWidget
+                                        clip: true
+                                        color: Qt.rgba(Theme.onSurface.r, Theme.onSurface.g, Theme.onSurface.b, 0.04)
+                                        border.width: 1
+                                        border.color: Qt.rgba(Theme.outline.r, Theme.outline.g, Theme.outline.b, 0.22)
+                                        Image {
+                                            anchors.fill: parent
+                                            anchors.margins: 8
+                                            source: PxCfg.Config.layerUrl(layerPanel.li)
+                                            cache: false
+                                            asynchronous: true
+                                            fillMode: Image.PreserveAspectFit
+                                            sourceSize.width: parent.width - 16
+                                            sourceSize.height: parent.height - 16
+                                            opacity: status === Image.Ready ? 1 : 0
+                                            Behavior on opacity { NumberAnimation { duration: Motion.crossfade } }
+                                        }
+                                    }
+
+                                    Sec { title: "Depth" }
+                                    DragSlider {
+                                        title: "Feather"
+                                        value: PxCfg.Config.featherFor(layerPanel.li - 1)
+                                        min: 0; max: 1; decimals: 2
+                                        onChanged: v => PxCfg.Config.setFeatherFor(layerPanel.li - 1, v)
+                                    }
+                                    DragSlider {
+                                        title: "Lift"
+                                        value: PxCfg.Config.liftFor(layerPanel.li - 1)
+                                        min: 0; max: 1; decimals: 2
+                                        onChanged: v => PxCfg.Config.setLiftFor(layerPanel.li - 1, v)
+                                    }
+                                    DragSlider {
+                                        title: "Shadow strength"
+                                        value: PxCfg.Config.shadowFor(layerPanel.li - 1)
+                                        min: 0; max: 1; decimals: 2
+                                        onChanged: v => PxCfg.Config.setShadowFor(layerPanel.li - 1, v)
+                                    }
+                                    Row {
+                                        width: parent.width
+                                        spacing: 12
+                                        AngleDial {
+                                            id: dial
+                                            angle: PxCfg.Config.shadowAngleFor(layerPanel.li - 1)
+                                            onChanged: deg => PxCfg.Config.setShadowAngleFor(layerPanel.li - 1, deg)
+                                        }
+                                        Column {
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            width: parent.width - 84 - 12
+                                            spacing: 2
+                                            Text {
+                                                text: "Shadow angle"
+                                                color: Theme.onSurface
+                                                font.family: Theme.fontPrimary
+                                                font.pixelSize: Theme.fontSm - 1
+                                                font.weight: Font.DemiBold
+                                            }
+                                            Text {
+                                                text: PxCfg.Config.shadowAngleFor(layerPanel.li - 1) + "\u00B0" + " - Drag the dot to set where the shadow falls."
+                                                wrapMode: Text.WordWrap
+                                                color: Theme.onSurfaceVariant
+                                                font.family: Theme.fontPrimary
+                                                font.pixelSize: Theme.fontSm - 3
+                                                width: parent.width
+                                            }
+                                        }
+                                    }
+
+                                    Sec { title: "Parallax" }
+                                    DragSlider {
+                                        title: "Parallax speed"
+                                        value: PxCfg.Config.parallaxFor(layerPanel.li - 1)
+                                        min: 0; max: 2; decimals: 1
+                                        onChanged: v => PxCfg.Config.setParallaxFor(layerPanel.li - 1, v)
+                                    }
+                                    DragSlider {
+                                        title: "Depth factor"
+                                        value: PxCfg.Config.depthFor(layerPanel.li - 1)
+                                        min: 0; max: 1; decimals: 2
+                                        onChanged: v => PxCfg.Config.setDepthFor(layerPanel.li - 1, v)
+                                    }
+                                    DragSlider {
+                                        title: "Max drift"
+                                        value: PxCfg.Config.mouseMaxFor(layerPanel.li - 1)
+                                        min: 0; max: 96; decimals: 0
+                                        unit: " px"
+                                        onChanged: v => PxCfg.Config.setMouseMaxFor(layerPanel.li - 1, v)
+                                    }
+
+                                    Sec { title: "Look" }
+                                    DragSlider {
+                                        title: "Opacity"
+                                        value: PxCfg.Config.opacityFor(layerPanel.li - 1)
+                                        min: 0; max: 1; decimals: 2
+                                        onChanged: v => PxCfg.Config.setOpacityFor(layerPanel.li - 1, v)
+                                    }
+                                    DragSlider {
+                                        title: "Offset X"
+                                        value: PxCfg.Config.offsetXFor(layerPanel.li - 1)
+                                        min: -400; max: 400; decimals: 0
+                                        unit: " px"
+                                        onChanged: v => PxCfg.Config.setOffsetXFor(layerPanel.li - 1, v)
+                                    }
+                                    DragSlider {
+                                        title: "Offset Y"
+                                        value: PxCfg.Config.offsetYFor(layerPanel.li - 1)
+                                        min: -400; max: 400; decimals: 0
+                                        unit: " px"
+                                        onChanged: v => PxCfg.Config.setOffsetYFor(layerPanel.li - 1, v)
+                                    }
+
+                                    Sec { title: "Motion" }
+                                    Field {
+                                        title: "Animation"
+                                        choices: [
+                                            { id: "none", label: "None" },
+                                            { id: "float", label: "Float" },
+                                            { id: "pulse", label: "Pulse" },
+                                            { id: "scale", label: "Scale" },
+                                            { id: "wiggle", label: "Wiggle" },
+                                            { id: "rotate", label: "Rotate" }
+                                        ]
+                                        current: PxCfg.Config.animTypeFor(layerPanel.li - 1)
+                                        onChose: id => PxCfg.Config.setAnimTypeFor(layerPanel.li - 1, id)
+                                    }
+                                    DragSlider {
+                                        title: "Animation speed"
+                                        value: PxCfg.Config.animSpeedFor(layerPanel.li - 1)
+                                        min: 0.1; max: 3; decimals: 1
+                                        visible: PxCfg.Config.animTypeFor(layerPanel.li - 1) !== "none"
+                                        onChanged: v => PxCfg.Config.setAnimSpeedFor(layerPanel.li - 1, v)
+                                    }
+                                    DragSlider {
+                                        title: "Animation amplitude"
+                                        value: PxCfg.Config.animAmplitudeFor(layerPanel.li - 1)
+                                        min: 0; max: 64; decimals: 0
+                                        visible: PxCfg.Config.animTypeFor(layerPanel.li - 1) !== "none"
+                                        onChanged: v => PxCfg.Config.setAnimAmpFor(layerPanel.li - 1, v)
+                                    }
+                                    DragSlider {
+                                        title: "Audio reactivity"
+                                        value: PxCfg.Config.audioLevelFor(layerPanel.li - 1)
+                                        min: 0; max: 1; decimals: 2
+                                        onChanged: v => PxCfg.Config.setAudioLevelFor(layerPanel.li - 1, v)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Sec { title: "Motion" }
+            PxTile {
+                width: parent.width
+                icon: "mouse"
+                label: "Mouse tracking"
+                sub: PxCfg.Config.mouseEnabled ? "On" : "Off"
+                on: PxCfg.Config.mouseEnabled
+                onToggled: {
+                    PxCfg.Config.mouseEnabled = !PxCfg.Config.mouseEnabled;
+                    PxCfg.Config.save();
+                }
+            }
+            DragSlider {
+                title: "Mouse sensitivity"
+                value: PxCfg.Config.mouseSensitivity
+                min: 0.05; max: 2; decimals: 2
+                onChanged: v => PxCfg.Config.setMouseSensitivity(v)
+            }
+            DragSlider {
+                title: "Drift range"
+                value: PxCfg.Config.mouseRange
+                min: 0.02; max: 1; decimals: 2
+                onChanged: v => PxCfg.Config.setMouseRange(v)
+            }
+            DragSlider {
+                title: "Wallpaper parallax"
+                value: PxCfg.Config.wallpaperParallax
+                min: 0; max: 1; decimals: 2
+                onChanged: v => PxCfg.Config.setWallpaperParallax(v)
+            }
+
+            Sec { title: "Presets" }
+            Field {
+                title: "Preset"
+                hint: "Applies a tuning to every layer at once. None restores the defaults."
+                choices: [
+                    { id: "none", label: "None" },
+                    { id: "softdepth", label: "Soft Depth" },
+                    { id: "audiopulse", label: "Audio Pulse" },
+                    { id: "cinematic", label: "Cinematic" }
+                ]
+                current: root.activePreset
+                onChose: id => {
+                    root.activePreset = id;
+                    PxCfg.Config.applyPreset(id);
+                }
+            }
+
+            PxNavRow {
+                width: parent.width
+                icon: "folder_open"
+                label: "Open cutouts folder"
+                onActivated: PxCfg.ParallaxBackend.openFolder()
+            }
+
+            Rectangle {
+                width: parent.width
+                height: engCol.implicitHeight + 20
+                radius: Theme.radiusWidget
+                color: Qt.rgba(Theme.onSurface.r, Theme.onSurface.g, Theme.onSurface.b, 0.04)
+                border.width: 1
+                border.color: Qt.rgba(Theme.outline.r, Theme.outline.g, Theme.outline.b, 0.18)
+                Column {
+                    id: engCol
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.top: parent.top
+                    anchors.margins: 10
+                    spacing: 5
+                    Row {
+                        width: parent.width
+                        spacing: 10
+                        MaterialIcon {
+                            anchors.verticalCenter: parent.verticalCenter
+                            text: "memory"
+                            font.pixelSize: 14
+                            color: Theme.onSurfaceVariant
+                        }
+                        Text {
+                            anchors.verticalCenter: parent.verticalCenter
+                            text: "Engine"
+                            color: Theme.onSurfaceVariant
+                            font.family: Theme.fontPrimary
+                            font.pixelSize: Theme.fontSm - 3
+                        }
+                        Text {
+                            anchors.verticalCenter: parent.verticalCenter
+                            text: PxCfg.ParallaxBackend.models.length + " models cached"
+                            color: Theme.onSurface
+                            font.family: Theme.fontPrimary
+                            font.pixelSize: Theme.fontSm - 3
+                        }
+                    }
+                    Text {
+                        width: parent.width
+                        text: "Mode: " + root.wallMode
+                        color: Theme.onSurfaceVariant
+                        font.family: Theme.fontPrimary
+                        font.pixelSize: Theme.fontSm - 3
+                    }
+                    Text {
+                        width: parent.width
+                        text: "Subject tier: " + PxCfg.Config.cutTier()
+                        color: Theme.onSurfaceVariant
+                        font.family: Theme.fontPrimary
+                        font.pixelSize: Theme.fontSm - 3
+                    }
+                    Text {
+                        width: parent.width
+                        text: "Layers: " + root.layerCount
+                        color: Theme.onSurfaceVariant
+                        font.family: Theme.fontPrimary
+                        font.pixelSize: Theme.fontSm - 3
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ryoku/shell/quickshell/shell/modules/desktop/Desktop.qml
+++ b/ryoku/shell/quickshell/shell/modules/desktop/Desktop.qml
@@ -15,6 +15,10 @@ import Ryoku.PluginKit
 import shell.services as Services
 import "../depth"
 import "../depth/Singletons" as DepthCfg
+import "../parallax"
+import "../parallax/Singletons" as ParallaxCfg
+import "../visualizer"
+import "../visualizer/Singletons" as VizCfg
 import "../wallpaper" as WallpaperMod
 
 // desktop widgets layer: WlrLayer.Bottom (below windows), instantiated once per
@@ -31,6 +35,7 @@ Scope {
     // controller hook; the desktop layer defaults on.
     property bool active: true
     property string wallpaperUrl: ""
+    property string wallpaperPath: ""
     property string wallpaperFit: "Cover"
     property string depthUrl: ""
     property var wallpaperTransition: null
@@ -42,6 +47,21 @@ Scope {
     // The ryogami-live yield flag (default "ryogami" engine): hide the painter
     // while the C player owns the background layer.
     property bool wallpaperLive: false
+    Binding {
+        target: ParallaxCfg.Config
+        property: "activePath"
+        value: root.wallpaperPath
+    }
+
+    // The parallax background surface (modules/parallax/ParallaxBackground.qml)
+    // owns the screen's backdrop while its layers are cut for this wallpaper.
+    readonly property bool parallaxOwns: ParallaxCfg.Config.enabled && ParallaxCfg.Config.wallActive
+        && root.videoUrl === "" && !root.wallpaperLive
+    function widgetZ(id) {
+        if (ParallaxCfg.Config.enabled && ParallaxCfg.Config.wallActive)
+            return ParallaxCfg.Config.widgetZ(id);
+        return DepthCfg.Config.isFront(id) ? 1 : 0;
+    }
     readonly property var depthState: Services.ShellState.forScreen(root.screen)
     // compose mode frees every widget for dragging (like visualiser placement),
     // so a locked clock can still be nestled into the subject; Done restores it.
@@ -188,6 +208,9 @@ Scope {
         WallpaperMod.Backdrop {
             id: backdrop
             anchors.fill: parent
+            // cava-bg model: while the parallax surface owns the background
+            // layer, this window only carries widgets and chrome.
+            visible: !root.parallaxOwns
             readonly property real screenDpr: (root.screen && root.screen.devicePixelRatio) ? root.screen.devicePixelRatio : 1
             dpr: screenDpr
             // Keep the still decoded while a video plays: the frame path is
@@ -265,7 +288,7 @@ Scope {
         WidgetSlot {
             id: clockSlot
             widget: "clock"
-            z: DepthCfg.Config.isFront("clock") ? 1 : 0
+            z: root.widgetZ("clock")
             visible: root.reloadReady && Config.clockEnabled
             anchor: Config.clockAnchor
             freeX: Config.clockX
@@ -283,7 +306,7 @@ Scope {
         WidgetSlot {
             id: calendarSlot
             widget: "calendar"
-            z: DepthCfg.Config.isFront("calendar") ? 1 : 0
+            z: root.widgetZ("calendar")
             visible: root.reloadReady && Config.calendarEnabled
             anchor: Config.calendarAnchor
             freeX: Config.calendarX
@@ -309,7 +332,7 @@ Scope {
         WidgetSlot {
             id: musicSlot
             widget: "music"
-            z: DepthCfg.Config.isFront("music") ? 1 : 0
+            z: root.widgetZ("music")
             visible: root.reloadReady && Config.musicEnabled
             anchor: Config.musicAnchor
             freeX: Config.musicX
@@ -338,7 +361,7 @@ Scope {
         WidgetSlot {
             id: aioSlot
             widget: "aio"
-            z: DepthCfg.Config.isFront("aio") ? 1 : 0
+            z: root.widgetZ("aio")
             visible: root.reloadReady && Config.aioEnabled
             anchor: Config.aioAnchor
             freeX: Config.aioX
@@ -358,7 +381,7 @@ Scope {
         WidgetSlot {
             id: statsSlot
             widget: "stats"
-            z: DepthCfg.Config.isFront("stats") ? 1 : 0
+            z: root.widgetZ("stats")
             visible: root.reloadReady && Config.statsEnabled
             anchor: Config.statsAnchor
             freeX: Config.statsX
@@ -377,7 +400,7 @@ Scope {
         WidgetSlot {
             id: weatherSlot
             widget: "weather"
-            z: DepthCfg.Config.isFront("weather") ? 1 : 0
+            z: root.widgetZ("weather")
             visible: root.reloadReady && Config.weatherEnabled
             anchor: Config.weatherAnchor
             freeX: Config.weatherX
@@ -397,7 +420,7 @@ Scope {
         WidgetSlot {
             id: notesSlot
             widget: "notes"
-            z: DepthCfg.Config.isFront("notes") ? 1 : 0
+            z: root.widgetZ("notes")
             visible: root.reloadReady && Config.notesEnabled
             anchor: Config.notesAnchor
             freeX: Config.notesX
@@ -504,6 +527,34 @@ Scope {
                 }
             }
         }
+        // Bands live here so the scene order interleaves them with the
+        // widgets; the drift follows the cursor the background polls.
+            Repeater {
+                id: parallaxBands
+                model: ParallaxCfg.Config.layers.length
+                delegate: ParallaxBand {
+                    required property int index
+                    anchors.fill: parent
+                    layerIndex: index + 1
+                    url: ParallaxCfg.Config.layerUrl(index + 1)
+                    fit: root.wallpaperFit
+                    z: ParallaxCfg.Config.sceneZ("layer:" + (index + 1))
+                    mouseNX: ParallaxCfg.Config.cursorNXFor(root.screen.name)
+                    mouseNY: ParallaxCfg.Config.cursorNYFor(root.screen.name)
+                    energy: VizCfg.Spectrum.energy
+                }
+            }
+
+        Item {
+            id: inlineViz
+            anchors.fill: parent
+            z: ParallaxCfg.Config.sceneZ("visualizer")
+            visible: root.parallaxOwns && VizCfg.Config.enabled
+            InlineVisualizer {
+                anchors.fill: parent
+            }
+        }
+
         // the wallpaper's subject, drawn in front of the widgets: above the
         // slots (declared later), below the menus and the photo viewer.
         DepthForeground {

--- a/ryoku/shell/quickshell/shell/modules/parallax/ParallaxBackground.qml
+++ b/ryoku/shell/quickshell/shell/modules/parallax/ParallaxBackground.qml
@@ -1,0 +1,148 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Wayland
+import Quickshell.Io
+import "Singletons"
+
+// The parallax backdrop surface at WlrLayer.Background: recoloured
+// background + drift. The layer bands render inside the desktop surface
+// so the scene order interleaves them with the widgets.
+Item {
+    id: root
+
+    property var screen
+    property string wallpaperUrl: ""
+    property string wallpaperPath: ""
+    property string wallpaperFit: "Cover"
+    property string videoUrl: ""
+    property bool wallpaperLive: false
+
+    readonly property bool owns: Config.enabled && Config.wallActive
+        && root.videoUrl === "" && !root.wallpaperLive
+
+    property real cursorNX: 0
+    property real cursorNY: 0
+
+    readonly property bool shown: root.owns && root.wallpaperUrl !== ""
+
+    property real _baseMax: Math.min(root.width * 0.04 * Config.mouseRange, root.width * 0.04)
+    function baseOffsetX() {
+        if (!Config.mouseEnabled) return 0;
+        return root.cursorNX * _baseMax * Config.wallpaperParallax * Config.mouseSensitivity;
+    }
+    function baseOffsetY() {
+        if (!Config.mouseEnabled) return 0;
+        return root.cursorNY * _baseMax * Config.wallpaperParallax * Config.mouseSensitivity;
+    }
+
+    function fillModeFor(im) {
+        switch (root.wallpaperFit) {
+        case "Contain": return Image.PreserveAspectFit;
+        case "Fill": return Image.Stretch;
+        case "ScaleDown":
+            return (im.sourceSize.width <= win.width && im.sourceSize.height <= win.height)
+                ? Image.Pad : Image.PreserveAspectFit;
+        default: return Image.PreserveAspectCrop;
+        }
+    }
+
+    PanelWindow {
+        id: win
+        screen: root.screen
+        visible: true
+        color: "transparent"
+        exclusionMode: ExclusionMode.Ignore
+        WlrLayershell.layer: WlrLayer.Background
+        WlrLayershell.namespace: "ryoku-parallax"
+        WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
+
+        mask: emptyRegion
+        Region { id: emptyRegion }
+
+        anchors { top: true; left: true; right: true; bottom: true }
+
+        Item {
+            id: stack
+            anchors.fill: parent
+            opacity: root.shown ? 1 : 0
+            Behavior on opacity { NumberAnimation { duration: 260; easing.type: Easing.OutCubic } }
+
+            Image {
+                id: base
+                anchors.fill: parent
+                source: root.wallpaperUrl
+                cache: false
+                asynchronous: true
+                fillMode: root.fillModeFor(base)
+                sourceSize.width: width
+                sourceSize.height: height
+                scale: 1.1
+                z: -1
+                transform: Translate {
+                    x: root.baseOffsetX()
+                    y: root.baseOffsetY()
+                    Behavior on x { SmoothedAnimation { velocity: 320; duration: 70 } }
+                    Behavior on y { SmoothedAnimation { velocity: 320; duration: 70 } }
+                }
+            }
+            Image {
+                id: bg
+                anchors.fill: parent
+                source: Config.backgroundUrl
+                cache: false
+                asynchronous: true
+                fillMode: root.fillModeFor(bg)
+                sourceSize.width: width
+                sourceSize.height: height
+                scale: 1.1
+                z: -1
+                visible: status === Image.Ready && Config.backgroundUrl !== ""
+                transform: Translate {
+                    x: root.baseOffsetX()
+                    y: root.baseOffsetY()
+                    Behavior on x { SmoothedAnimation { velocity: 320; duration: 70 } }
+                    Behavior on y { SmoothedAnimation { velocity: 320; duration: 70 } }
+                }
+            }
+
+        }
+    }
+
+    Timer {
+        id: cursorTick
+        interval: 40
+        repeat: true
+        running: root.owns
+        onTriggered: {
+            const m = root.screen;
+            if (!m || m.width <= 0) return;
+            cursorProc.running = false;
+            cursorProc.running = true;
+        }
+    }
+    Process {
+        id: cursorProc
+        command: ["hyprctl", "cursorpos"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const m = root.screen;
+                if (!m || m.width <= 0) return;
+                const parts = ("" + this.text).trim().split(",");
+                if (parts.length !== 2) return;
+                const cx = parseFloat(parts[0]);
+                const cy = parseFloat(parts[1]);
+                if (isNaN(cx) || isNaN(cy)) return;
+                const mx = (cx - m.x) / m.width * 2 - 1;
+                const my = (cy - m.y) / m.height * 2 - 1;
+                const nx = Math.max(-1, Math.min(1, mx));
+                const ny = Math.max(-1, Math.min(1, my));
+                // Smoothed so the irregular poll timing never jitters.
+                root.cursorNX = root.cursorNX + (nx - root.cursorNX) * 0.55;
+                root.cursorNY = root.cursorNY + (ny - root.cursorNY) * 0.55;
+                Config.setCursor(root.screen.name, root.cursorNX, root.cursorNY);
+            }
+        }
+    }
+}

--- a/ryoku/shell/quickshell/shell/modules/parallax/ParallaxBand.qml
+++ b/ryoku/shell/quickshell/shell/modules/parallax/ParallaxBand.qml
@@ -1,0 +1,127 @@
+pragma ComponentBehavior: Bound
+import QtQuick
+import QtQuick.Effects
+import "Singletons"
+
+// One parallax layer: an alpha PNG at its scene z with cursor drift,
+// feather, lift, angled shadow and idle animation from the config.
+Item {
+    id: root
+
+    property int layerIndex: 1
+    property string url: ""
+    property string fit: "Cover"
+    property real mouseNX: 0
+    property real mouseNY: 0
+    property real energy: 0
+
+    readonly property int i: root.layerIndex - 1
+    readonly property bool enabled: root.url !== "" && Config.enabled && Config.wallActive
+        && Config.layerEnabled2(root.i)
+        && Config.sceneIndexOf("layer:" + root.layerIndex) >= 0
+
+    anchors.fill: parent
+    visible: root.enabled
+
+    function _fillMode(im) {
+        switch (root.fit) {
+        case "Contain": return Image.PreserveAspectFit;
+        case "Fill": return Image.Stretch;
+        case "ScaleDown":
+            return (im.sourceSize.width <= root.width && im.sourceSize.height <= root.height) ? Image.Pad : Image.PreserveAspectFit;
+        default: return Image.PreserveAspectCrop;
+        }
+    }
+
+    function _maxShift() {
+        return Math.min(Config.mouseMaxFor(root.i), root.width * 0.04 * Config.mouseRange);
+    }
+    function _cursorX() {
+        if (!Config.mouseEnabled) return 0;
+        return root.mouseNX * _maxShift() * 0.8
+            * Config.parallaxFor(root.i) * (0.4 + Config.depthFor(root.i) * 1.2)
+            * Config.mouseSensitivity;
+    }
+    function _cursorY() {
+        if (!Config.mouseEnabled) return 0;
+        return root.mouseNY * _maxShift() * 0.8
+            * Config.parallaxFor(root.i) * (0.4 + Config.depthFor(root.i) * 1.2)
+            * Config.mouseSensitivity;
+    }
+
+    function _audioY() {
+        const a = Config.audioLevelFor(root.i);
+        if (a <= 0) return 0;
+        return -root.energy * a * 24;
+    }
+
+    readonly property real _lift: Config.liftFor(root.i)
+
+
+    readonly property string _anim: Config.animTypeFor(root.i)
+    readonly property real _amp: Config.animAmplitudeFor(root.i)
+    readonly property real _spd: Config.animSpeedFor(root.i)
+    readonly property int _dur: Math.max(500, Math.round(3200 / Math.max(0.1, _spd)))
+
+    property real animT: 0
+    Timer {
+        id: animTick
+        interval: 50
+        repeat: true
+        running: root.enabled && root._anim !== "none"
+        onTriggered: root.animT += 50
+    }
+
+    readonly property real _phase: root.animT * 2 * Math.PI * 4 / _dur
+    readonly property real _animX: (_anim === "float" || _anim === "wiggle" || _anim === "rotate")
+        ? Math.sin(_phase) * _amp : 0
+    readonly property real _animY: (_anim === "float" || _anim === "wiggle")
+        ? Math.cos(_phase) * _amp : 0
+    readonly property real _animOpacity: _anim === "pulse"
+        ? 0.55 + 0.45 * Math.abs(Math.sin(_phase / 2)) : 1
+    readonly property real _animScale: _anim === "scale"
+        ? 1.1 + _amp / 200 * Math.sin(_phase / 2) : 1
+    readonly property real _animRotate: _anim === "rotate"
+        ? Math.sin(_phase) * _amp * 0.35 : 0
+
+    readonly property real _shAngle: Config.shadowAngleFor(root.i) * Math.PI / 180
+    readonly property real _shStrength: Config.shadowFor(root.i)
+
+    Image {
+        id: img
+        anchors.fill: parent
+        source: root.url
+        cache: false
+        asynchronous: true
+        fillMode: root._fillMode(img)
+        sourceSize.width: root.width
+        sourceSize.height: root.height
+        scale: 1.1 * root._animScale * (1 + root._lift * 0.06)
+        rotation: root._animRotate
+        opacity: (status === Image.Ready ? Config.opacityFor(root.i) : 0) * root._animOpacity
+        Behavior on opacity { NumberAnimation { duration: 320; easing.type: Easing.OutCubic } }
+
+        transform: Translate {
+            // Interpolates between the ~25 Hz poll updates for fluid motion.
+            x: root._cursorX() + Config.offsetXFor(root.i) + root._animX
+            y: root._cursorY() + root._audioY() + Config.offsetYFor(root.i) + root._animY - root._lift * 10
+            Behavior on x { SmoothedAnimation { velocity: 320; duration: 70 } }
+            Behavior on y { SmoothedAnimation { velocity: 320; duration: 70 } }
+        }
+
+        // Same shadow recipe as the depth effect; the angle knob steers
+        // the horizontal/vertical offsets.
+        layer.enabled: Config.featherFor(root.i) > 0.001 || root._shStrength > 0.001
+        layer.effect: MultiEffect {
+            id: fx
+            blurEnabled: Config.featherFor(root.i) > 0.001
+            blurMax: 16
+            blur: Config.featherFor(root.i)
+            shadowEnabled: root._shStrength > 0.001
+            shadowColor: Qt.rgba(0, 0, 0, 0.72 * root._shStrength)
+            shadowBlur: 0.55 + 0.45 * root._shStrength
+            shadowHorizontalOffset: Math.round(Math.cos(root._shAngle) * 20 * root._shStrength)
+            shadowVerticalOffset: Math.round(Math.sin(root._shAngle) * 20 * root._shStrength)
+        }
+    }
+}

--- a/ryoku/shell/quickshell/shell/modules/parallax/Singletons/Config.qml
+++ b/ryoku/shell/quickshell/shell/modules/parallax/Singletons/Config.qml
@@ -1,0 +1,458 @@
+pragma ComponentBehavior: Bound
+pragma Singleton
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// Parallax module config (docs/parallax.md). Auto mode runs
+// ryoku-parallax-engine (subject + recoloured background); manual mode
+// lists the wallpaper's folder. Every artifact lives in
+// ~/Pictures/Parallax/<stem>/.
+Singleton {
+    id: root
+
+    property alias enabled: adapter.enabled
+    property alias mode: adapter.mode
+    property alias model: adapter.model
+    property alias alphaMatting: adapter.alphaMatting
+    property alias bands: adapter.bands
+
+    property alias mouseEnabled: adapter.mouseEnabled
+    property real mouseSensitivity: adapter.mouseSensitivity
+    property real mouseRange: adapter.mouseRange
+
+    property real wallpaperParallax: adapter.wallpaperParallax
+
+    // Per-layer knob arrays (index 0 = layer 1, back of the scene).
+    property var parallax: adapter.parallax
+    property var opacity: adapter.opacity
+    property var depth: adapter.depth
+    property var offsetX: adapter.offsetX
+    property var offsetY: adapter.offsetY
+    property var mouseMax: adapter.mouseMax
+    property var audioLevel: adapter.audioLevel
+    property var animType: adapter.animType
+    property var animSpeed: adapter.animSpeed
+    property var animAmplitude: adapter.animAmplitude
+    property var shadow: adapter.shadow
+    property var shadowAngle: adapter.shadowAngle
+    property var feather: adapter.feather
+    property var lift: adapter.lift
+    property var layerEnabled: adapter.layerEnabled
+
+    property alias scene: adapter.scene
+
+    property var _reg: ({})
+
+    property int wallBands: 0
+    readonly property var bandCount: Math.max(1, Math.min(8, root.wallBands > 0 ? root.wallBands : (adapter.bands || 1)))
+    readonly property var builtinWidgetIds: ["clock", "calendar", "music", "aio", "stats", "weather", "notes"]
+
+    property string activePath: ""
+    property bool wallActive: false
+    property string wallMode: "auto"
+    property string backgroundUrl: ""
+    property string cutProgress: ""
+    // Per-monitor cursor (-1..1); a single shared pair made two monitors
+    // fight over the values and the layers trembled.
+    property var _cursor: ({})
+    function setCursor(name, nx, ny) {
+        const next = {};
+        for (const k in root._cursor)
+            next[k] = root._cursor[k];
+        next[name] = { nx: nx, ny: ny };
+        root._cursor = next;
+    }
+    function cursorNXFor(name) {
+        const e = root._cursor && root._cursor[name];
+        return e ? e.nx : 0;
+    }
+    function cursorNYFor(name) {
+        const e = root._cursor && root._cursor[name];
+        return e ? e.ny : 0;
+    }
+    readonly property string progressPath: (Quickshell.env("XDG_STATE_HOME") || (Quickshell.env("HOME") + "/.local/state")) + "/ryoku/parallax/progress"
+    property var layers: []
+    property var wallScene: []
+
+    function wallStem() {
+        if (root.activePath === "") return "";
+        const base = root.activePath.split("/").pop();
+        return base.replace(/\.[^.]+$/, "");
+    }
+    function wallFolder() {
+        const stem = root.wallStem();
+        if (stem === "") return "";
+        return (Quickshell.env("HOME") || "") + "/Pictures/Parallax/" + stem;
+    }
+    function backgroundOutUrl() {
+        const folder = root.wallFolder();
+        if (folder === "") return "";
+        // The subject's rev changes per re-cut, so the surface reloads the
+        // recoloured background instead of keeping the old texture.
+        const ls = root._reg.layers && root.activePath ? root._reg.layers[root.activePath] : null;
+        const rev = (ls && ls.length && ls[0].rev) ? ls[0].rev : 0;
+        return "file://" + folder + "/background.png?v=" + rev;
+    }
+
+    function _recompute() {
+        const p = root.activePath;
+        const reg = root._reg;
+        const w = reg.walls && p ? reg.walls[p] : null;
+        const ls = reg.layers && p ? reg.layers[p] : null;
+        if (!p) {
+            root.wallActive = false;
+            root.layers = [];
+            root.wallScene = [];
+            root.wallMode = root.mode;
+            root.wallBands = 0;
+            root.backgroundUrl = "";
+            return;
+        }
+        root.wallActive = !!(w && w.enabled && ls && ls.length);
+        root.layers = (w && w.enabled && ls) ? ls : [];
+        root.wallScene = (w && w.scene && w.scene.length) ? w.scene : [];
+        root.wallBands = (w && w.enabled && ls) ? ls.length : 0;
+        root.wallMode = (w && w.mode) ? w.mode : root.mode;
+        root.backgroundUrl = (w && w.mode === "auto") ? root.backgroundOutUrl() : "";
+    }
+    onActivePathChanged: root._recompute()
+
+    function setWallEnabled(on) {
+        if (!root.activePath) return;
+        wallProc.command = ["ryoku-shell", "parallax", "set-enabled", on ? "1" : "0"];
+        wallProc.running = false;
+        wallProc.running = true;
+    }
+    function setMode(mode) {
+        if (mode !== "auto" && mode !== "manual") return;
+        adapter.mode = mode;
+        root.wallMode = mode;
+        file.writeAdapter();
+        if (!root.activePath) return;
+        modeProc.command = ["ryoku-shell", "parallax", "set-mode", mode];
+        modeProc.running = false;
+        modeProc.running = true;
+    }
+    function setCutTier(tier) {
+        if (tier === "fine") { adapter.model = "birefnet-general-lite"; adapter.alphaMatting = true; }
+        else if (tier === "standard") { adapter.model = "u2netp"; adapter.alphaMatting = true; }
+        else { adapter.model = "u2netp"; adapter.alphaMatting = false; }
+        save();
+        root.refresh();
+    }
+    function cutTier() {
+        if (adapter.model === "birefnet-general-lite") return "fine";
+        return adapter.alphaMatting ? "standard" : "draft";
+    }
+    function refresh() {
+        if (!root.activePath) return;
+        refreshProc.running = false;
+        refreshProc.running = true;
+    }
+    function cancel() {
+        cancelProc.running = false;
+        cancelProc.running = true;
+        root.cutProgress = "cancelled";
+    }
+    function setEnabledGlobal(on) {
+        adapter.enabled = on === true;
+        save();
+        root.ensureDefaults();
+    }
+    function removeManualLayer(layerPath) {
+        if (!root.activePath || !layerPath) return;
+        removeLayerProc.command = ["ryoku-shell", "parallax", "remove-layer", layerPath];
+        removeLayerProc.running = false;
+        removeLayerProc.running = true;
+    }
+    Process {
+        id: wallProc
+        command: ["ryoku-shell", "parallax", "set-enabled", "0"]
+    }
+    Process {
+        id: modeProc
+        command: ["ryoku-shell", "parallax", "set-mode", "auto"]
+    }
+    Process {
+        id: refreshProc
+        command: ["ryoku-shell", "parallax", "refresh"]
+    }
+    Process {
+        id: cancelProc
+        command: ["ryoku-shell", "parallax", "cancel"]
+    }
+    Process {
+        id: sceneProc
+        command: ["ryoku-shell", "parallax", "set-scene", "[]"]
+    }
+    Process {
+        id: removeLayerProc
+        command: ["ryoku-shell", "parallax", "remove-layer", ""]
+    }
+
+    function _arr(a, i, def) {
+        return (a && i >= 0 && i < a.length && a[i] !== undefined) ? a[i] : def;
+    }
+    function layerEnabled2(i)  { return root._arr(adapter.layerEnabled, i, true) === true; }
+    function parallaxFor(i)    { return root._arr(adapter.parallax, i, 1); }
+    function opacityFor(i)     { return root._arr(adapter.opacity, i, 1); }
+    function depthFor(i)       { return root._arr(adapter.depth, i, 0.5); }
+    function offsetXFor(i)     { return root._arr(adapter.offsetX, i, 0); }
+    function offsetYFor(i)     { return root._arr(adapter.offsetY, i, 0); }
+    function mouseMaxFor(i)    { return root._arr(adapter.mouseMax, i, 32); }
+    function audioLevelFor(i)  { return root._arr(adapter.audioLevel, i, 0); }
+    function animTypeFor(i)    { return root._arr(adapter.animType, i, "none"); }
+    function animSpeedFor(i)   { return root._arr(adapter.animSpeed, i, 0.5); }
+    function animAmplitudeFor(i) { return root._arr(adapter.animAmplitude, i, 10); }
+    function shadowFor(i)      { return root._arr(adapter.shadow, i, 0); }
+    function shadowAngleFor(i) { return root._arr(adapter.shadowAngle, i, 90); }
+    function featherFor(i)     { return root._arr(adapter.feather, i, 0); }
+    function liftFor(i)        { return root._arr(adapter.lift, i, 0); }
+
+    function _def(arr) {
+        switch (arr) {
+        case adapter.layerEnabled: return true;
+        case adapter.parallax: return 1;
+        case adapter.opacity: return 1;
+        case adapter.depth: return 0.5;
+        case adapter.mouseMax: return 32;
+        case adapter.audioLevel: return 0;
+        case adapter.animType: return "none";
+        case adapter.animSpeed: return 0.5;
+        case adapter.animAmplitude: return 10;
+        case adapter.shadow: return 0;
+        case adapter.shadowAngle: return 90;
+        case adapter.feather: return 0;
+        case adapter.lift: return 0;
+        }
+        return 0;
+    }
+    function _set(arr, i, v) {
+        const a = (arr || []).slice();
+        while (a.length <= i) a.push(_def(arr));
+        a[i] = v;
+        return a;
+    }
+
+    function setLayerEnabled2(i, v) { adapter.layerEnabled = _set(adapter.layerEnabled, i, v === true); save(); }
+    function setParallaxFor(i, v) { adapter.parallax = _set(adapter.parallax, i, Math.max(0, Math.min(2, v))); save(); }
+    function setOpacityFor(i, v) { adapter.opacity = _set(adapter.opacity, i, Math.max(0, Math.min(1, v))); save(); }
+    function setDepthFor(i, v) { adapter.depth = _set(adapter.depth, i, Math.max(0, Math.min(1, v))); save(); }
+    function setOffsetXFor(i, v) { adapter.offsetX = _set(adapter.offsetX, i, Math.round(v)); save(); }
+    function setOffsetYFor(i, v) { adapter.offsetY = _set(adapter.offsetY, i, Math.round(v)); save(); }
+    function setMouseMaxFor(i, v) { adapter.mouseMax = _set(adapter.mouseMax, i, Math.max(0, Math.min(96, Math.round(v)))); save(); }
+    function setAudioLevelFor(i, v) { adapter.audioLevel = _set(adapter.audioLevel, i, Math.max(0, Math.min(1, v))); save(); }
+    function setAnimTypeFor(i, v) { adapter.animType = _set(adapter.animType, i, v); save(); }
+    function setAnimSpeedFor(i, v) { adapter.animSpeed = _set(adapter.animSpeed, i, Math.max(0.1, Math.min(3, v))); save(); }
+    function setAnimAmpFor(i, v) { adapter.animAmplitude = _set(adapter.animAmplitude, i, Math.max(0, Math.min(64, Math.round(v)))); save(); }
+    function setShadowFor(i, v) { adapter.shadow = _set(adapter.shadow, i, Math.max(0, Math.min(1, v))); save(); }
+    function setShadowAngleFor(i, v) { adapter.shadowAngle = _set(adapter.shadowAngle, i, Math.round(v)); save(); }
+    function setFeatherFor(i, v) { adapter.feather = _set(adapter.feather, i, Math.max(0, Math.min(1, v))); save(); }
+    function setLiftFor(i, v) { adapter.lift = _set(adapter.lift, i, Math.max(0, Math.min(1, v))); save(); }
+
+    function setMouseSensitivity(v) { adapter.mouseSensitivity = Math.max(0.05, Math.min(2, v)); save(); }
+    function setMouseRange(v) { adapter.mouseRange = Math.max(0.02, Math.min(1, v)); save(); }
+    function setWallpaperParallax(v) { adapter.wallpaperParallax = Math.max(0, Math.min(1, v)); save(); }
+
+    // None resets the defaults; the rest tune the whole stack at once.
+    function applyPreset(id) {
+        const n = root.bandCount;
+        var pl = [], dp = [], al = [], amp = [], spd = [], ft = [], lf = [];
+        for (var i = 0; i < n; i++) {
+            const t = n <= 1 ? 0.5 : i / (n - 1);
+            switch (id) {
+            case "softdepth":
+                pl.push(1 - t * 0.4); dp.push(0.2 + t * 0.8); al.push(0); amp.push(4); spd.push(0.4); ft.push(0); lf.push(0.1 + t * 0.3);
+                break;
+            case "audiopulse":
+                pl.push(0.9); dp.push(0.5); al.push(0.6); amp.push(8); spd.push(0.8); ft.push(0.1); lf.push(0.3);
+                break;
+            case "cinematic":
+                pl.push(1.4 - t * 0.4); dp.push(0.3 + t * 0.4); al.push(0.15); amp.push(16); spd.push(0.15); ft.push(0.2); lf.push(0.5);
+                break;
+            default: // none
+                pl.push(1); dp.push(0.5); al.push(0); amp.push(10); spd.push(0.5); ft.push(0); lf.push(0);
+                break;
+            }
+        }
+        adapter.parallax = pl;
+        adapter.depth = dp;
+        adapter.audioLevel = al;
+        adapter.animAmplitude = amp;
+        adapter.animSpeed = spd;
+        adapter.feather = ft;
+        adapter.lift = lf;
+        for (var j = 0; j < n; j++) {
+            adapter.animType = _set(adapter.animType, j, id === "none" ? "none" : "float");
+            adapter.shadow = _set(adapter.shadow, j, id === "cinematic" ? 0.5 : 0);
+        }
+        save();
+    }
+
+    function save() { file.writeAdapter(); }
+
+    function defaultScene() {
+        const out = ["wallpaper"];
+        for (var i = 1; i <= root.bandCount; i++) out.push("layer:" + i);
+        for (const w of root.builtinWidgetIds) out.push("widget:" + w);
+        out.push("visualizer");
+        return out;
+    }
+    function sceneOr(name) { return root.effectiveScene().indexOf(name); }
+    function effectiveScene() {
+        if (root.wallScene && root.wallScene.length) return root.wallScene;
+        return (adapter.scene && adapter.scene.length) ? adapter.scene : root.defaultScene();
+    }
+    function sceneIndexOf(name) { return root.sceneOr(name); }
+    function sceneZ(name) {
+        const i = root.sceneOr(name);
+        return i < 0 ? 0 : i * 2 + 1;
+    }
+    function sceneGapZ() {
+        const s = root.effectiveScene();
+        for (var i = s.length - 1; i >= 0; i--)
+            if (s[i].indexOf("layer:") === 0) return i * 2 + 1.5;
+        return 1;
+    }
+    function widgetZ(id) {
+        const name = "widget:" + id;
+        const i = root.sceneOr(name);
+        return i >= 0 ? i * 2 + 2 : root.sceneGapZ();
+    }
+    function setScene(arr) {
+        const list = arr ? arr.slice() : [];
+        if (root.activePath) {
+            sceneProc.command = ["ryoku-shell", "parallax", "set-scene", JSON.stringify(list)];
+            sceneProc.running = false;
+            sceneProc.running = true;
+            root.wallScene = list;
+            return;
+        }
+        adapter.scene = list;
+        save();
+    }
+
+    function layerLabel(i) {
+        const ls = root.layers;
+        const lbl = (i >= 1 && i <= ls.length && ls[i - 1].label) ? ls[i - 1].label : "";
+        if (lbl) return lbl.charAt(0).toUpperCase() + lbl.slice(1);
+        return "Layer %1".arg(i);
+    }
+    function layerDepth(i) {
+        const ls = root.layers;
+        if (i < 1 || i > ls.length) return -1;
+        const d = ls[i - 1].depth;
+        return typeof d === "number" ? d : -1;
+    }
+    function layerArea(i) {
+        const ls = root.layers;
+        if (i < 1 || i > ls.length) return -1;
+        const a = ls[i - 1].area;
+        return typeof a === "number" ? a : -1;
+    }
+    function layerUrl(i) {
+        const ls = root.layers;
+        if (i < 1 || i > ls.length) return "";
+        return "file://" + ls[i - 1].out + "?v=" + ls[i - 1].rev;
+    }
+    function layerPath(i) {
+        const ls = root.layers;
+        if (i < 1 || i > ls.length) return "";
+        return ls[i - 1].out;
+    }
+    function isLayerReady(i) { return root.layerUrl(i) !== ""; }
+
+    function ensureDefaults() {
+        const n = root.bandCount;
+        function grow(arr, def) {
+            let a = arr;
+            if (!a) { a = []; }
+            while (a.length < n) a.push(def);
+            return a;
+        }
+        adapter.parallax = grow(adapter.parallax, 1);
+        adapter.opacity = grow(adapter.opacity, 1);
+        adapter.depth = grow(adapter.depth, 0.5);
+        adapter.offsetX = grow(adapter.offsetX, 0);
+        adapter.offsetY = grow(adapter.offsetY, 0);
+        adapter.mouseMax = grow(adapter.mouseMax, 32);
+        adapter.audioLevel = grow(adapter.audioLevel, 0);
+        adapter.animType = grow(adapter.animType, "none");
+        adapter.animSpeed = grow(adapter.animSpeed, 0.5);
+        adapter.animAmplitude = grow(adapter.animAmplitude, 10);
+        adapter.shadow = grow(adapter.shadow, 0);
+        adapter.shadowAngle = grow(adapter.shadowAngle, 90);
+        adapter.feather = grow(adapter.feather, 0);
+        adapter.lift = grow(adapter.lift, 0);
+        adapter.layerEnabled = grow(adapter.layerEnabled, true);
+    }
+    onEnabledChanged: root.ensureDefaults()
+    onWallBandsChanged: root.ensureDefaults()
+
+    FileView {
+        id: file
+        path: (Quickshell.env("XDG_CONFIG_HOME") || (Quickshell.env("HOME") + "/.config")) + "/ryoku/parallax.json"
+        blockLoading: true
+        watchChanges: true
+        printErrors: false
+        atomicWrites: true
+        onFileChanged: reload()
+
+        JsonAdapter {
+            id: adapter
+            property bool enabled: false
+            property string mode: "auto"
+            property string model: "u2netp"
+            property bool alphaMatting: false
+            property int bands: 1
+            property bool mouseEnabled: true
+            property real mouseSensitivity: 0.9
+            property real mouseRange: 1.0
+            property real wallpaperParallax: 0.5
+            property var parallax: []
+            property var opacity: []
+            property var depth: []
+            property var offsetX: []
+            property var offsetY: []
+            property var mouseMax: []
+            property var audioLevel: []
+            property var animType: []
+            property var animSpeed: []
+            property var animAmplitude: []
+            property var shadow: []
+            property var shadowAngle: []
+            property var feather: []
+            property var lift: []
+            property var layerEnabled: []
+            property var scene: []
+        }
+    }
+
+    FileView {
+        id: wallsFile
+        path: (Quickshell.env("HOME") || "") + "/Pictures/Parallax/layers.pz"
+        blockLoading: true
+        watchChanges: true
+        printErrors: false
+        atomicWrites: true
+        onFileChanged: reload()
+        onLoaded: {
+            try {
+                root._reg = JSON.parse(wallsFile.text());
+            } catch (e) {
+                root._reg = {};
+            }
+            root._recompute();
+            root.ensureDefaults();
+        }
+    }
+
+    Component.onCompleted: {
+        if (!file.text())
+            file.writeAdapter();
+        root.ensureDefaults();
+        if (wallsFile.text())
+            wallsFile.reload();
+    }
+}

--- a/ryoku/shell/quickshell/shell/modules/parallax/Singletons/ParallaxBackend.qml
+++ b/ryoku/shell/quickshell/shell/modules/parallax/Singletons/ParallaxBackend.qml
@@ -1,0 +1,120 @@
+pragma ComponentBehavior: Bound
+pragma Singleton
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// Availability and provisioning for the standalone parallax engine
+// (docs/parallax.md); own state dir, no dependency on the depth install.
+Singleton {
+    id: root
+
+    readonly property string bin: {
+        const d = Quickshell.env("RYOKU_SHELL_DIR");
+        return (d && d.length > 0) ? d + "/scripts/ryoku-parallax-engine" : "ryoku-parallax-engine";
+    }
+
+    property bool available: false
+    property bool installing: false
+    property bool removing: false
+    property var models: []
+    property string progress: ""
+
+    function recheck() {
+        checkProc.running = false;
+        checkProc.running = true;
+    }
+    function install(model) {
+        if (root.installing)
+            return;
+        root.installing = true;
+        root.progress = "";
+        installProc.command = (model && model.length > 0)
+            ? [root.bin, "install", model] : [root.bin, "install"];
+        installProc.running = false;
+        installProc.running = true;
+    }
+    function remove(model) {
+        if (root.removing || root.installing || !model || model.length === 0)
+            return;
+        root.removing = true;
+        root.progress = "";
+        removeProc.command = [root.bin, "remove", model];
+        removeProc.running = false;
+        removeProc.running = true;
+    }
+    function hasModel(m) {
+        return (root.models || []).indexOf(m) >= 0;
+    }
+    function openFolder() {
+        openProc.running = false;
+        openProc.running = true;
+    }
+    function openManualFolderFor(wallPath) {
+        if (!wallPath) return;
+        const base = wallPath.split("/").pop();
+        const stem = base.replace(/\.[^.]+$/, "");
+        const folder = (Quickshell.env("HOME") || "") + "/Pictures/Parallax/" + stem;
+        openProc.command = ["sh", "-c",
+            "mkdir -p \"" + folder + "\" && (nautilus \"" + folder + "\" 2>/dev/null || gio open \"" + folder + "\" 2>/dev/null || xdg-open \"" + folder + "\")"];
+        openProc.running = false;
+        openProc.running = true;
+    }
+
+    property bool checked: false
+
+    Process {
+        id: checkProc
+        command: [root.bin, "check"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                root.available = ("" + this.text).trim() === "available";
+                if (root.available)
+                    modelsProc.running = true;
+                else
+                    root.checked = true;
+            }
+        }
+    }
+    Process {
+        id: modelsProc
+        command: [root.bin, "models"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const out = [];
+                const lines = ("" + this.text).split("\n");
+                for (var i = 0; i < lines.length; i++) {
+                    const t = lines[i].trim();
+                    if (t.length > 0)
+                        out.push(t);
+                }
+                root.models = out;
+                root.checked = true;
+            }
+        }
+    }
+    Process {
+        id: installProc
+        stdout: SplitParser { onRead: line => root.progress = line }
+        stderr: SplitParser { onRead: line => root.progress = line }
+        onExited: {
+            root.installing = false;
+            root.recheck();
+        }
+    }
+    Process {
+        id: removeProc
+        stdout: SplitParser { onRead: line => root.progress = line }
+        stderr: SplitParser { onRead: line => root.progress = line }
+        onExited: {
+            root.removing = false;
+            root.recheck();
+        }
+    }
+    Process {
+        id: openProc
+        command: ["sh", "-c", "d=\"$HOME/Pictures/Parallax\"; mkdir -p \"$d\"; nautilus \"$d\" 2>/dev/null || gio open \"$d\" 2>/dev/null || xdg-open \"$d\""]
+    }
+
+    Component.onCompleted: root.recheck()
+}

--- a/ryoku/shell/quickshell/shell/modules/parallax/Singletons/qmldir
+++ b/ryoku/shell/quickshell/shell/modules/parallax/Singletons/qmldir
@@ -1,0 +1,2 @@
+singleton Config Config.qml
+singleton ParallaxBackend ParallaxBackend.qml

--- a/ryoku/shell/quickshell/shell/modules/visualizer/InlineVisualizer.qml
+++ b/ryoku/shell/quickshell/shell/modules/visualizer/InlineVisualizer.qml
@@ -1,0 +1,19 @@
+pragma ComponentBehavior: Bound
+import QtQuick
+import "Singletons"
+
+// The visualiser stack without its own surface: the desktop hosts one at
+// the visualizer's scene z while parallax owns the background, so the
+// bars sit between the parallax layers.
+Item {
+    id: root
+
+    Repeater {
+        model: Config.count
+        delegate: VisualizerView {
+            required property int index
+            anchors.fill: parent
+            cfg: VizItem { data: Config.dataAt(index) }
+        }
+    }
+}

--- a/ryoku/shell/quickshell/shell/modules/visualizer/Visualizer.qml
+++ b/ryoku/shell/quickshell/shell/modules/visualizer/Visualizer.qml
@@ -26,6 +26,7 @@ Item {
     // own surface (Placer), and rides the top layer so it is not buried while
     // being aimed.
     property bool placing: false
+    property bool suppressed: false
     signal placingDone
 
     readonly property bool active: root.mode !== "off"
@@ -43,7 +44,7 @@ Item {
     Binding {
         target: Spectrum
         property: "active"
-        value: root.active
+        value: root.active || root.suppressed
     }
 
     // one shared cava for every instance, at the largest band count any of them
@@ -74,7 +75,7 @@ Item {
         id: win
 
         screen: root.screen
-        visible: root.active
+        visible: root.active && !root.suppressed
         color: "transparent"
 
         // The curtain hangs off the bar, so its surface honours the bar's

--- a/ryoku/shell/quickshell/shell/modules/wallpaper/Wallpaper.qml
+++ b/ryoku/shell/quickshell/shell/modules/wallpaper/Wallpaper.qml
@@ -34,6 +34,7 @@ Item {
     }
     readonly property string wallpaperUrl: frame.path.length > 0
         ? "file://" + frame.path + "?v=" + frame.revision : ""
+    readonly property string wallpaperPath: frame.path
     readonly property string depthUrl: frame.depth.length > 0
         ? "file://" + frame.depth + "?v=" + frame.depthRev : ""
     readonly property string fit: frame.fit

--- a/ryoku/shell/quickshell/shell/shell.qml
+++ b/ryoku/shell/quickshell/shell/shell.qml
@@ -16,6 +16,8 @@ import "components"
 import "modules/wallpaper"
 import "modules/desktop"
 import "modules/visualizer"
+import "modules/parallax"
+import "modules/parallax/Singletons" as ParallaxCfg
 import "modules/bar"
 import "modules/dock"
 import "modules/launcher"
@@ -170,6 +172,7 @@ ShellRoot {
                 screen: perScreen.modelData
                 active: true
                 wallpaperUrl: wallpaper.wallpaperUrl
+                wallpaperPath: wallpaper.wallpaperPath
                 wallpaperFit: wallpaper.fit
                 depthUrl: wallpaper.depthUrl
                 wallpaperTransition: wallpaper.transition
@@ -178,11 +181,26 @@ ShellRoot {
                 videoMuted: wallpaper.videoMuted
                 videoVolume: wallpaper.videoVolume
             }
+
+            // The parallax composition lives at WlrLayer.Background, below
+            // this slice: its own surface draws the wallpaper + layers while
+            // the desktop window above only carries widgets and chrome.
+            ParallaxBackground {
+                screen: perScreen.modelData
+                wallpaperUrl: wallpaper.wallpaperUrl
+                wallpaperPath: wallpaper.wallpaperPath
+                wallpaperFit: wallpaper.fit
+                videoUrl: wallpaper.videoUrl
+                wallpaperLive: wallpaper.live
+            }
             Visualizer {
+                id: perScreenViz
                 screen: perScreen.modelData
                 mode: !VizCfg.Config.enabled ? "off"
                     : (perScreen.st && perScreen.st.visualizerOverlay ? "overlay" : "desktop")
                 placing: perScreen.st ? perScreen.st.visualizerPlacing : false
+                suppressed: ParallaxCfg.Config.enabled && ParallaxCfg.Config.wallActive
+                    && VizCfg.Config.enabled && !perScreenViz.placing
                 onPlacingDone: if (perScreen.st) perScreen.st.visualizerPlacing = false
             }
 

--- a/ryoku/shell/scripts/ryoku-parallax-engine
+++ b/ryoku/shell/scripts/ryoku-parallax-engine
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+# Standalone parallax cutout engine (docs/parallax.md): `cutout` produces the
+# subject's alpha-matted PNG and `inpaint` recolours the cutout's hole with
+# the surrounding colour, so a drifted subject reveals the backdrop instead
+# of its own ghost. Own venv and model cache; no dependency on ryoku-depth.
+set -euo pipefail
+
+state="${XDG_STATE_HOME:-$HOME/.local/state}/ryoku/parallax"
+venv="$state/venv"
+models="$state/models"
+export REMBG_HOME="$models"
+export U2NET_HOME="$models" # older rembg reads this name
+
+curated=(u2netp birefnet-general-lite)
+default_model="u2netp"
+
+is_curated() {
+    local m
+    for m in "${curated[@]}"; do
+        [[ "$1" == "$m" ]] && return 0
+    done
+    return 1
+}
+
+rembg_python() {
+    if [[ -x "$venv/bin/python" ]] && "$venv/bin/python" -c "import rembg" 2>/dev/null; then
+        PY="$venv/bin/python"
+        return 0
+    fi
+    local p
+    for p in python3.13 python3.12 python3.11 python3; do
+        command -v "$p" >/dev/null 2>&1 || continue
+        if "$p" -c "import rembg" 2>/dev/null; then
+            PY="$p"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# rembg's cache layout varies by version, so find the onnx rather than assume a path.
+model_cached() { [[ -n "$(find "$models" -name "$1.onnx" -print -quit 2>/dev/null)" ]]; }
+
+cmd_check() {
+    if rembg_python && model_cached "$default_model"; then
+        printf 'available\n'
+        return 0
+    fi
+    printf 'missing\n'
+    return 1
+}
+
+cmd_models() {
+    rembg_python || return 1
+    local m any=0
+    for m in "${curated[@]}"; do
+        if model_cached "$m"; then
+            printf '%s\n' "$m"
+            any=1
+        fi
+    done
+    [[ $any == 1 ]]
+}
+
+cmd_cutout() {
+    local in="" out="" model="$default_model" matting=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+        -m | --model)
+            model="${2:-}"
+            shift 2
+            ;;
+        --alpha-matting)
+            matting=1
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            printf 'ryoku-parallax-engine: unknown option %s\n' "$1" >&2
+            return 2
+            ;;
+        *)
+            if [[ -z $in ]]; then in="$1"; elif [[ -z $out ]]; then out="$1"; fi
+            shift
+            ;;
+        esac
+    done
+    [[ -z $in && $# -gt 0 ]] && {
+        in="$1"
+        shift
+    }
+    [[ -z $out && $# -gt 0 ]] && {
+        out="$1"
+        shift
+    }
+
+    if [[ -z $in || -z $out ]]; then
+        printf 'usage: ryoku-parallax-engine cutout <in> <out.png> [--model <id>] [--alpha-matting]\n' >&2
+        return 2
+    fi
+    [[ -f "$in" ]] || {
+        printf 'ryoku-parallax-engine: input not found: %s\n' "$in" >&2
+        return 1
+    }
+    is_curated "$model" || model="$default_model"
+
+    rembg_python || {
+        printf 'ryoku-parallax-engine: engine not installed (run: ryoku-parallax-engine install)\n' >&2
+        return 1
+    }
+    model_cached "$model" || {
+        printf 'ryoku-parallax-engine: model %s not downloaded\n' "$model" >&2
+        return 1
+    }
+
+    mkdir -p "$(dirname -- "$out")"
+    local tmp
+    tmp="$(mktemp "${out}.XXXXXX")"
+    if "$PY" - "$in" "$tmp" "$model" "$matting" <<'PY'
+import sys
+from rembg import new_session, remove
+inp, out, model = sys.argv[1], sys.argv[2], sys.argv[3]
+matting = sys.argv[4] == "1"
+try:
+    session = new_session(model, providers=["CUDAExecutionProvider", "CPUExecutionProvider"])
+except TypeError:  # rembg too old for providers=
+    session = new_session(model)
+with open(inp, "rb") as f:
+    data = f.read()
+kw = dict(session=session)
+if matting:
+    # Alpha matting refines the silhouette (hair, fur, soft edges) at some cost
+    # in time; the thresholds are rembg's, tuned for a clean foreground.
+    kw.update(alpha_matting=True, alpha_matting_foreground_threshold=240,
+              alpha_matting_background_threshold=10, alpha_matting_erode_size=10)
+with open(out, "wb") as f:
+    f.write(remove(data, **kw))
+PY
+    then
+        if [[ -s "$tmp" ]]; then
+            mv -f "$tmp" "$out"
+            printf '%s\n' "$out"
+            return 0
+        fi
+    fi
+    rm -f "$tmp"
+    printf 'ryoku-parallax-engine: cutout failed\n' >&2
+    return 1
+}
+
+# Hole recolouring: takes the original wallpaper + the subject cutout's alpha
+# channel as the hole mask and writes an RGB PNG whose hole pixels carry the
+# mean colour of the surrounding background ring (the "recoloured background").
+# No AI here: one dilate + one mean over the ring, so the pass is a couple of
+# seconds and fully deterministic; the parallax surface renders this as its
+# base and the drifted subject reveals the backdrop, not its own silhouette.
+cmd_inpaint() {
+    local in="" mask="" out=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+        --)
+            shift
+            break
+            ;;
+        -*)
+            printf 'ryoku-parallax-engine inpaint: unknown option %s\n' "$1" >&2
+            return 2
+            ;;
+        *)
+            if [[ -z $in ]]; then in="$1"; elif [[ -z $mask ]]; then mask="$1"; elif [[ -z $out ]]; then out="$1"; fi
+            shift
+            ;;
+        esac
+    done
+
+    if [[ -z $in || -z $mask || -z $out ]]; then
+        printf 'usage: ryoku-parallax-engine inpaint <image> <mask> <out.png>\n' >&2
+        return 2
+    fi
+    [[ -f "$in" ]] || {
+        printf 'ryoku-parallax-engine: image not found: %s\n' "$in" >&2
+        return 1
+    }
+    [[ -f "$mask" ]] || {
+        printf 'ryoku-parallax-engine: mask not found: %s\n' "$mask" >&2
+        return 1
+    }
+    rembg_python || {
+        printf 'ryoku-parallax-engine: engine not installed (run: ryoku-parallax-engine install)\n' >&2
+        return 1
+    }
+
+    mkdir -p "$(dirname -- "$out")"
+    local tmp
+    tmp="$(mktemp "${out}.XXXXXX")"
+    if "$PY" - "$in" "$mask" "$tmp" <<'PY'
+import sys
+import numpy as np
+from PIL import Image
+from scipy import ndimage
+
+image_path, mask_path, out_path = sys.argv[1:4]
+
+img = Image.open(image_path).convert("RGB")
+mask_rgba = Image.open(mask_path).convert("RGBA")
+if mask_rgba.size != img.size:
+    mask_rgba = mask_rgba.resize(img.size, Image.BILINEAR)
+
+alpha = np.asarray(mask_rgba, dtype=np.uint8)[..., 3]
+# Solid blob for the hole: fill interior fragments, close gaps, then widen
+# the rim so nothing dark survives (the subject PNG covers the margin).
+hole = ndimage.binary_fill_holes(alpha > 25)
+hole = ndimage.binary_closing(hole, iterations=8)
+hole = ndimage.binary_dilation(hole, iterations=4)
+src = np.asarray(img, dtype=np.uint8)
+
+ring = ndimage.binary_dilation(hole, iterations=14) & ~hole
+if ring.sum() > 0:
+    fill = src[ring].mean(axis=0).astype(np.uint8)
+else:
+    fill = np.array([128, 128, 128], dtype=np.uint8)
+
+result = src.copy()
+result[hole] = fill
+Image.fromarray(result, "RGB").save(out_path, "PNG")
+PY
+    then
+        if [[ -s "$tmp" ]]; then
+            mv -f "$tmp" "$out"
+            printf '%s\n' "$out"
+            return 0
+        fi
+    fi
+    rm -f "$tmp"
+    printf 'ryoku-parallax-engine: inpaint failed\n' >&2
+    return 1
+}
+
+pick_python() {
+    # rembg needs Python 3.11-3.13; the system python3 may be newer.
+    local p ver
+    for p in python3.13 python3.12 python3.11 python3; do
+        command -v "$p" >/dev/null 2>&1 || continue
+        ver="$("$p" -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null)" || continue
+        case "$ver" in
+        3.11 | 3.12 | 3.13)
+            printf '%s\n' "$p"
+            return 0
+            ;;
+        esac
+    done
+    return 1
+}
+
+# A system Python 3.11-3.13 is the fast path; otherwise uv provisions one.
+ensure_venv() {
+    [[ -x "$venv/bin/python" ]] && return 0
+    local py
+    if py="$(pick_python)"; then
+        printf 'Creating engine environment (%s)...\n' "$py"
+        "$py" -m venv "$venv"
+        return 0
+    fi
+    if command -v uv >/dev/null 2>&1; then
+        printf 'Provisioning Python 3.13 via uv...\n'
+        uv python install 3.13 && uv venv --python 3.13 "$venv"
+        [[ -x "$venv/bin/python" ]] && return 0
+    fi
+    printf 'ryoku-parallax-engine: needs Python 3.11-3.13 or uv (install it: sudo pacman -S uv)\n' >&2
+    return 1
+}
+
+venv_pip() {
+    if [[ -x "$venv/bin/pip" ]]; then
+        "$venv/bin/pip" install --quiet "$@"
+        return
+    fi
+    uv pip install --quiet --python "$venv/bin/python" "$@"
+}
+
+cmd_install() {
+    local want=("$@")
+    [[ ${#want[@]} -eq 0 ]] && want=("$default_model")
+
+    mkdir -p "$state" "$models"
+    ensure_venv || return 1
+
+    printf 'Installing rembg (CPU)...\n'
+    [[ -x "$venv/bin/pip" ]] && venv_pip --upgrade pip
+    if ! venv_pip "rembg[cpu]"; then
+        printf 'ryoku-parallax-engine: could not install rembg (no onnxruntime wheel for this Python?)\n' >&2
+        return 1
+    fi
+
+    local m
+    for m in "${want[@]}"; do
+        is_curated "$m" || continue
+        printf 'Downloading model %s...\n' "$m"
+        "$venv/bin/python" - "$m" <<'PY'
+import sys
+from rembg import new_session
+model = sys.argv[1]
+try:
+    new_session(model, providers=["CUDAExecutionProvider", "CPUExecutionProvider"])
+except Exception:
+    new_session(model)
+PY
+    done
+
+    if cmd_check >/dev/null; then
+        printf 'done\n'
+        return 0
+    fi
+    printf 'ryoku-parallax-engine: install finished but the engine is still unavailable\n' >&2
+    return 1
+}
+
+cmd_remove() {
+    local m="${1:-}"
+    [[ -n $m ]] || {
+        printf 'usage: ryoku-parallax-engine remove <model>\n' >&2
+        return 2
+    }
+    is_curated "$m" || {
+        printf 'ryoku-parallax-engine: not a curated model: %s\n' "$m" >&2
+        return 2
+    }
+    local f found=0
+    while IFS= read -r -d '' f; do
+        rm -f "$f"
+        found=1
+    done < <(find "$models" -name "$m.onnx" -print0 2>/dev/null)
+    if [[ $found -eq 1 ]]; then
+        printf 'removed %s\n' "$m"
+    else
+        printf '%s was not installed\n' "$m"
+    fi
+    return 0
+}
+
+case "${1:-}" in
+check) cmd_check ;;
+models)
+    shift
+    cmd_models
+    ;;
+cutout)
+    shift
+    cmd_cutout "$@"
+    ;;
+inpaint)
+    shift
+    cmd_inpaint "$@"
+    ;;
+install)
+    shift
+    cmd_install "$@"
+    ;;
+remove)
+    shift
+    cmd_remove "$@"
+    ;;
+*)
+    printf 'usage: ryoku-parallax-engine check | models | cutout <in> <out.png> [--model <id>] [--alpha-matting] | inpaint <image> <mask> <out.png> | install [model...] | remove <model>\n' >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## What changed

The Super+Esc quick settings gains a **Parallax** tab (beside Depth) that turns the active wallpaper into movable layers:

- **Auto mode**: a standalone engine (`ryoku-parallax-engine`, own venv/model cache, no dependency on `ryoku-depth`) cuts the subject and *recolours the cutout's hole* with the surrounding colour, so a drifted layer reveals the backdrop instead of its own ghost. Cuts are reused by mtime.
- **Manual mode**: drop `layer-NN.png` files into the wallpaper's folder; the daemon lists them (`add-layer`/`remove-layer` with a path-traversal guard).
- **Per-layer knobs**: parallax, depth, opacity, offsets, feather, lift, shadow with a draggable direction dial, audio reactivity, idle animation (float/pulse/scale/wiggle/rotate), plus presets and drag-only sliders.
- **Scene order editor**: reorders layers, active widgets and the audio visualizer on screen (real z), persisted per wallpaper.
- While parallax owns the background, the audio visualizer draws inline between layers; off, behaviour is unchanged.

Docs: `docs/parallax.md` (module contract, engine commands, registry schema, wiring).

## Area

global

## How it was tested

On a running Ryoku box: cut the default wallpaper in auto mode and watched the cut progress through the engine stream; enabled parallax, dragged the sidebar sliders and the shadow dial and watched each layer retune live; reordered the scene list and watched a widget move between layers; switched to manual mode with hand-dropped `layer-NN.png` files; verified a refresh while cutting and one within 10 s of a finish are no-ops. Ran the full `ryoku-shell` Go test suite, `go vet`, `qmllint` on every touched QML file, `bash -n` on the engine script, the slop scanner and the delivery verifier. Checked side by side with depth: off, desktop behaviour is identical.

## Checklist

- [x] One logical change, with a clear `[area] scope: summary` commit subject.
- [x] Matching `CHANGELOG.md` updated in the area I touched.
- [x] The git hooks pass locally; I did not use `--no-verify`.
- [x] Lua parses (`luac -p`), shell scripts pass `bash -n`, and QML passes
      `qmllint` where applicable.
- [x] No duplicated config, no dead code, no commented-out code, no em-dash.
- [x] Docs updated if behavior or layout changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added parallax wallpaper support with automatic or manual layer creation.
  * Added a Parallax tab in Quick Settings for enabling effects, managing layers, adjusting motion, depth, opacity, shadows, audio response, and animations.
  * Added scene ordering for wallpaper layers, widgets, and the audio visualizer.
  * Added cursor-responsive backgrounds and optional inline visualizer placement.
  * Added engine status, model management, progress reporting, cancellation, and refresh controls.
* **Documentation**
  * Added comprehensive Parallax setup and configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->