### PR TITLE
Stop ryoku doctor re-writing the SDDM greeter config on every run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@ for finer detail.
 - The overview's new-workspace controls now allocate workspace ids globally, so
   clicking `+` or `NEW` on a secondary monitor creates the workspace on that
   monitor instead of jumping to an existing workspace on another output.
+- `ryoku doctor` no longer re-writes the SDDM greeter config when it's already
+  correct: `readFileSafe` strips the trailing newline on read-back while the
+  expected body kept one, so a byte-correct file always looked out of date and
+  the sudo rewrite failed silently when no TTY was available. The comparison
+  now ignores the trailing newline.
 - Limine now shows the generated boot menu: the branded config moved from
   `/boot/limine/limine.conf` (which Limine scans first, shadowing everything
   `limine-entry-tool` generates into `/boot/limine.conf`: the UKI tree and the

--- a/ryoku/cli/internal/doctor/doctor.go
+++ b/ryoku/cli/internal/doctor/doctor.go
@@ -2353,7 +2353,7 @@ func reconcileGreeterDisplayServer(checkOnly bool) recResult {
 	}
 	want := sddmWaylandBody()
 	have := readFileSafe(sddmWaylandConf)
-	if have == want {
+	if have == strings.TrimRight(want, "\n") {
 		return okRes("SDDM greeter runs on Wayland (weston kiosk)")
 	}
 	if have != "" {


### PR DESCRIPTION
## What's happening

`ryoku doctor` shows a red X on the "SDDM greeter" check even when everything is actually configured correctly:

```
✗ SDDM greeter display server — could not write /etc/sddm.conf.d/10-ryoku-wayland.conf
```

The config file on disk is already exactly right, so it feels like a false positive because it is.

## Why

`readFileSafe` strips the trailing newline when it reads the file back, but `sddmWaylandBody()` builds the expected content ending in `\n`. So `have` it reads and `want` it compares against never match, no matter how many times the file gets written to disk:

- `have`  → `[General]\nDisplayServer=wayland\n...` (no trailing newline)
- `want`  → `[General]\nDisplayServer=wayland\n...\n` (trailing newline)

Since the strings never compare equal, the check falls through and tries to re-write the file as root. When running non-interactively (no sudo TTY), that write fails and the check reports broken even though the file is fine.

## The fix

Compare against the expected body with the trailing newline trimmed:

```go
if have == strings.TrimRight(want, "\n")
```

Now a byte-correct config is recognised as already correct and the check passes, no rewrite attempted. Screwed-up config still gets flagged and fixed as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary rewrites of SDDM greeter configuration files when their content differs only by a trailing newline.
  - Reduced silent failures from avoidable configuration updates requiring elevated permissions or an interactive terminal.

- **Documentation**
  - Added a changelog entry describing the improved configuration comparison behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->