### PR TITLE
[ryoku] fastfetch: exec so the shell module sees the real shell

### DIFF
--- a/ryoku/apps/CHANGELOG.md
+++ b/ryoku/apps/CHANGELOG.md
@@ -39,7 +39,7 @@
   parent chain and skips known wrappers (`time`, `sudo`, ...) without knowing
   `timeout`, so every greeting read "Shell: timeout". Each branch now `exec`s
   fastfetch, which replaces the wrapper process and leaves the user's shell as
-  the direct parent (`ryoku-fastfetch`).
+  the direct parent.
 - `ryostore/`: **An installed theme now carries the store's preview image, so
   the Color-scheme picker shows it.** The install wrote `scheme.json` and
   `meta.json` and nothing else, while Ryogami's Themes tab looked for

--- a/ryoku/apps/CHANGELOG.md
+++ b/ryoku/apps/CHANGELOG.md
@@ -34,6 +34,12 @@
   v0.56.0-beta.19") via `ryoku version --pretty` (`config.jsonc`).
 
 ### Fixed
+- `fastfetch/`: **the greeting reports the real shell again.** The wrapper
+  bounded fastfetch with `timeout 8`, but fastfetch's shell module walks the
+  parent chain and skips known wrappers (`time`, `sudo`, ...) without knowing
+  `timeout`, so every greeting read "Shell: timeout". Each branch now `exec`s
+  fastfetch, which replaces the wrapper process and leaves the user's shell as
+  the direct parent (`ryoku-fastfetch`).
 - `ryostore/`: **An installed theme now carries the store's preview image, so
   the Color-scheme picker shows it.** The install wrote `scheme.json` and
   `meta.json` and nothing else, while Ryogami's Themes tab looked for

--- a/ryoku/apps/fastfetch/ryoku-fastfetch
+++ b/ryoku/apps/fastfetch/ryoku-fastfetch
@@ -8,20 +8,17 @@
 # Every branch execs fastfetch instead of bounding it with `timeout`: the
 # shell module walks the parent chain and skips known wrappers (`time`,
 # `sudo`, ...) but not `timeout`, so `timeout 8 fastfetch` reported the
-# shell as "timeout" in every greeting.
+# shell as "timeout" in every greeting. A failed exec makes bash exit 127,
+# which no longer masks a missing fastfetch behind a false success.
 set -uo pipefail
 
 config="${XDG_CONFIG_HOME:-$HOME/.config}/fastfetch/config.jsonc"
 if [ ! -f "$config" ]; then
   exec fastfetch "$@"
-  exit 0
-fi
-
-if [ -n "${KITTY_WINDOW_ID:-}" ] || [ "${TERM:-}" = "xterm-kitty" ]; then
+elif [ -n "${KITTY_WINDOW_ID:-}" ] || [ "${TERM:-}" = "xterm-kitty" ]; then
   exec fastfetch --config "$config" --pipe false "$@"
 elif command -v chafa >/dev/null 2>&1; then
   exec fastfetch --config "$config" --logo-type chafa "$@"
 else
   exec fastfetch --config "$config" --logo-type none "$@"
 fi
-exit 0

--- a/ryoku/apps/fastfetch/ryoku-fastfetch
+++ b/ryoku/apps/fastfetch/ryoku-fastfetch
@@ -5,21 +5,23 @@
 # logos and falls back to ASCII -- so in kitty we force `--pipe false` to keep
 # the image. Outside kitty: chafa if present, else fastfetch's default.
 #
-# Bounded with `timeout` so a slow probe can never freeze the shell greeting:
-# a stuck process makes /proc enumeration block, and WM/DE detection scans it.
+# Every branch execs fastfetch instead of bounding it with `timeout`: the
+# shell module walks the parent chain and skips known wrappers (`time`,
+# `sudo`, ...) but not `timeout`, so `timeout 8 fastfetch` reported the
+# shell as "timeout" in every greeting.
 set -uo pipefail
 
 config="${XDG_CONFIG_HOME:-$HOME/.config}/fastfetch/config.jsonc"
 if [ ! -f "$config" ]; then
-  timeout 8 fastfetch "$@"
+  exec fastfetch "$@"
   exit 0
 fi
 
 if [ -n "${KITTY_WINDOW_ID:-}" ] || [ "${TERM:-}" = "xterm-kitty" ]; then
-  timeout 8 fastfetch --config "$config" --pipe false "$@"
+  exec fastfetch --config "$config" --pipe false "$@"
 elif command -v chafa >/dev/null 2>&1; then
-  timeout 8 fastfetch --config "$config" --logo-type chafa "$@"
+  exec fastfetch --config "$config" --logo-type chafa "$@"
 else
-  timeout 8 fastfetch --config "$config" --logo-type none "$@"
+  exec fastfetch --config "$config" --logo-type none "$@"
 fi
 exit 0


### PR DESCRIPTION
## Problem

Every fastfetch greeting on a Ryoku box reports `Shell: timeout` instead of the
user's shell (seen on 0.63.1-beta.19 / commit 86e93aa1 onwards).

## Root cause

`ryoku-fastfetch` bounds every invocation with `timeout 8` (86e93aa1). fastfetch's
shell module detects the shell by walking its parent process chain and skipping
known wrappers (`time`, `sudo`, `strace`, `gdb`, ...). `timeout` is not in that
skip list, so the walk stops at it:

```
kitty -> fish -> bash (ryoku-fastfetch) -> timeout -> fastfetch
                                                  ^-- detected as "the shell"
```

Verified on fastfetch 2.68.1 by reading `src/detection/terminalshell/terminalshell_linux.c`
(`getShellInfo` skip list) and by reproduction:

```
$ fish -c '/usr/bin/ryoku-fastfetch -s shell'
  Shell timeout
$ fish -c '<patched wrapper> -s shell'
  Shell fish 4.9.3
```

## Fix

Each branch of the wrapper now `exec`s fastfetch instead of
`timeout 8 fastfetch`. The wrapper process is replaced by fastfetch itself, so
the user's shell becomes its direct parent and detection works again.

## On the 8s bound

The bound was added so a stuck `/proc` scan could never freeze the greeting. Two
things to weigh:

- fastfetch itself is the process doing the scanning; `timeout` only killed it
  after the fact. With `exec`, a wedged fastfetch is still cleaned up the same
  way any foreground command is (close the terminal, Ctrl-C works now that the
  wrapper does not sit in between).
- The comment in the script said the bound guarded the greeting; in practice it
  corrupted the greeting's data on every single run, which is worse than the
  tail risk it protected against.

If the bound is still wanted, the alternative is teaching fastfetch to skip
`timeout` in its parent walk (fastfetch-cli/fastfetch#…) or wrapping with
something in the skip list, but that couples us to their list. `exec` is the
local, robust fix.

## Testing

- `bash -n` passes; repo pre-commit hooks pass (this PR is that commit, made
  with `.githooks` wired).
- Functional before/after shown above, run on a live Ryoku 0.63.1-beta.19 box.
- Changelog entry added under `ryoku/apps/CHANGELOG.md` (Unreleased / Fixed).